### PR TITLE
Fix FTBFS with gcc 4.7 by fixing the missing <unistd.h> include

### DIFF
--- a/src/yafraycore/scene.cc
+++ b/src/yafraycore/scene.cc
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <limits>
 #include <sstream>
+#include <unistd.h>
 
 __BEGIN_YAFRAY
 


### PR DESCRIPTION
- Reference http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=667426
