### PR TITLE
Fixed include unistd.h for MSVC

### DIFF
--- a/src/yafraycore/scene.cc
+++ b/src/yafraycore/scene.cc
@@ -39,7 +39,9 @@
 #include <iostream>
 #include <limits>
 #include <sstream>
-#include <unistd.h>
+#if HAVE_UNISTD_H
+	#include <unistd.h>
+#endif
 
 __BEGIN_YAFRAY
 


### PR DESCRIPTION
- MSVC does not have <unistd.h> header
  Reference: http://lists.gnu.org/archive/html/bug-gnulib/2011-09/msg00145.html
