### PR TITLE
CMake changes to define HAVE_UNISTD_H

### DIFF
--- a/CMakeConfig/GenConfHeaders.txt
+++ b/CMakeConfig/GenConfHeaders.txt
@@ -6,3 +6,6 @@ endif(NOT YAF_REVISION)
 configure_file(CMakeConfig/templates/yaf_revision.h.cmake ${CMAKE_BINARY_DIR}/yaf_revision.h)
 configure_file(CMakeConfig/templates/yafray_config.h.cmake ${CMAKE_BINARY_DIR}/yafray_config.h)
 
+include(CheckIncludeFiles)
+check_include_files(unistd.h HAVE_UNISTD_H)
+configure_file(CMakeConfig/templates/yafray_config.h.cmake ${CMAKE_BINARY_DIR}/yafray_config.h)

--- a/CMakeConfig/templates/yafray_config.h.cmake
+++ b/CMakeConfig/templates/yafray_config.h.cmake
@@ -14,6 +14,8 @@
 #define Y_LOG yafout.error() << setColor(Cyan) << "LOG: " << setColor()
 #define yendl std::endl
 
+#cmakedefine HAVE_UNISTD_H 1
+
 __BEGIN_YAFRAY
 typedef float CFLOAT;
 typedef float GFLOAT;


### PR DESCRIPTION
- let cmake check for unistd.h and define
  the HAVE_UNISTD_H macro.
