### PR TITLE
Missing initialization of "intpb" in Integrators

### DIFF
--- a/src/integrators/DebugIntegrator.cc
+++ b/src/integrators/DebugIntegrator.cc
@@ -49,6 +49,7 @@ class YAFRAYPLUGIN_EXPORT DebugIntegrator : public tiledIntegrator_t
 DebugIntegrator::DebugIntegrator(SurfaceProperties dt)
 {
 	type = SURFACE;
+	intpb = 0;
 	debugType = dt;
 	integratorName = "DebugIntegrator";
 	integratorShortName = "DBG";

--- a/src/integrators/pathtracer.cc
+++ b/src/integrators/pathtracer.cc
@@ -54,6 +54,7 @@ class YAFRAYPLUGIN_EXPORT pathIntegrator_t: public mcIntegrator_t
 pathIntegrator_t::pathIntegrator_t(bool transpShad, int shadowDepth)
 {
 	type = SURFACE;
+	intpb = 0;
 	trShad = transpShad;
 	sDepth = shadowDepth;
 	causticType = PATH;


### PR DESCRIPTION
-added missing initializiation of intpb in Debug-
and Pathtracing Integrators, crashes Blender if
render method is set to "Image File".

Fixes this Bugreport:
http://www.yafaray.org/node/497
