### PR TITLE
Shiny Diffuse Material:

### DIFF
--- a/src/materials/shinydiff.cc
+++ b/src/materials/shinydiff.cc
@@ -192,12 +192,12 @@ CFLOAT shinyDiffuseMat_t::OrenNayar(const vector3d_t &wi, const vector3d_t &wo, 
 	if(cos_to >= cos_ti)
 	{
 		sin_alpha = fSqrt(1.f - cos_ti*cos_ti);
-		tan_beta = fSqrt(1.f - cos_to*cos_to) / (cos_to == 0.f)?1e-8f:cos_to; // white (black on windows) dots fix for oren-nayar, could happen with bad normals
+		tan_beta = fSqrt(1.f - cos_to*cos_to) / ((cos_to == 0.f)?1e-8f:cos_to); // white (black on windows) dots fix for oren-nayar, could happen with bad normals
 	}
 	else
 	{
 		sin_alpha = fSqrt(1.f - cos_to*cos_to);
-		tan_beta = fSqrt(1.f - cos_ti*cos_ti) / (cos_ti == 0.f)?1e-8f:cos_ti; // white (black on windows) dots fix for oren-nayar, could happen with bad normals
+		tan_beta = fSqrt(1.f - cos_ti*cos_ti) / ((cos_ti == 0.f)?1e-8f:cos_ti); // white (black on windows) dots fix for oren-nayar, could happen with bad normals
 	}
 	
 	return A + B * maxcos_f * sin_alpha * tan_beta;


### PR DESCRIPTION
- Silenced MSVC compiler warnings.
- struct of SDDat_t has only 6 elements:
  A call of the 'memset' function can lead to
  overflow of the buffer 'dat'.
