### PR TITLE
Glossy, Coated Glossy Materials:

### DIFF
--- a/src/materials/coatedglossy.cc
+++ b/src/materials/coatedglossy.cc
@@ -142,12 +142,12 @@ float coatedGlossyMat_t::OrenNayar(const vector3d_t &wi, const vector3d_t &wo, c
 	if(cos_to >= cos_ti)
 	{
 		sin_alpha = fSqrt(1.f - cos_ti*cos_ti);
-		tan_beta = fSqrt(1.f - cos_to*cos_to) / (cos_to == 0.f)?1e-8f:cos_to; // white (black on windows) dots fix for oren-nayar, could happen with bad normals
+		tan_beta = fSqrt(1.f - cos_to*cos_to) / ((cos_to == 0.f)?1e-8f:cos_to); // white (black on windows) dots fix for oren-nayar, could happen with bad normals
 	}
 	else
 	{
 		sin_alpha = fSqrt(1.f - cos_to*cos_to);
-		tan_beta = fSqrt(1.f - cos_ti*cos_ti) / (cos_ti == 0.f)?1e-8f:cos_ti; // white (black on windows) dots fix for oren-nayar, could happen with bad normals
+		tan_beta = fSqrt(1.f - cos_ti*cos_ti) / ((cos_ti == 0.f)?1e-8f:cos_ti); // white (black on windows) dots fix for oren-nayar, could happen with bad normals
 	}
 	
 	return orenA + orenB * maxcos_f * sin_alpha * tan_beta;
@@ -472,7 +472,7 @@ material_t* coatedGlossyMat_t::factory(paraMap_t &params, std::list< paraMap_t >
 	
 	if(mat->loadNodes(paramList, render))
 	{
-		for(actNode = nodeList.begin(); actNode != nodeList.end(); actNode++)
+		for(actNode = nodeList.begin(); actNode != nodeList.end(); ++actNode)
 		{
 			if(params.getParam(actNode->first, name))
 			{

--- a/src/materials/glossy_mat.cc
+++ b/src/materials/glossy_mat.cc
@@ -120,12 +120,12 @@ float glossyMat_t::OrenNayar(const vector3d_t &wi, const vector3d_t &wo, const v
 	if(cos_to >= cos_ti)
 	{
 		sin_alpha = fSqrt(1.f - cos_ti*cos_ti);
-		tan_beta = fSqrt(1.f - cos_to*cos_to) / (cos_to == 0.f)?1e-8f:cos_to; // white (black on windows) dots fix for oren-nayar, could happen with bad normals
+		tan_beta = fSqrt(1.f - cos_to*cos_to) / ((cos_to == 0.f)?1e-8f:cos_to); // white (black on windows) dots fix for oren-nayar, could happen with bad normals
 	}
 	else
 	{
 		sin_alpha = fSqrt(1.f - cos_to*cos_to);
-		tan_beta = fSqrt(1.f - cos_ti*cos_ti) / (cos_ti == 0.f)?1e-8f:cos_ti; // white (black on windows) dots fix for oren-nayar, could happen with bad normals
+		tan_beta = fSqrt(1.f - cos_ti*cos_ti) / ((cos_ti == 0.f)?1e-8f:cos_ti); // white (black on windows) dots fix for oren-nayar, could happen with bad normals
 	}
 	
 	return orenA + orenB * maxcos_f * sin_alpha * tan_beta;


### PR DESCRIPTION
-Silenced MSVC compiler warning about:
"Perhaps the '?:' operator works in a different way than it was expected.
The '?:' operator has a lower priority than the '/' operator."

-Changed 'actNode++' iterator to '++actNode', decreased performance.
 In case 'actNode' is iterator it's more effective to use prefix form of increment.
