### PR TITLE
Replaced iterator++ with ++iterator

### DIFF
--- a/src/materials/glass.cc
+++ b/src/materials/glass.cc
@@ -307,7 +307,7 @@ material_t* glassMat_t::factory(paraMap_t &params, std::list< paraMap_t > &param
 	
 	if(mat->loadNodes(paramList, render))
 	{
-		for(actNode = nodeList.begin(); actNode != nodeList.end(); actNode++)
+		for(actNode = nodeList.begin(); actNode != nodeList.end(); ++actNode)
 		{
 			if(params.getParam(actNode->first, name))
 			{

--- a/src/materials/glossy_mat.cc
+++ b/src/materials/glossy_mat.cc
@@ -402,7 +402,7 @@ material_t* glossyMat_t::factory(paraMap_t &params, std::list< paraMap_t > &para
 	
 	if(mat->loadNodes(paramList, render))
 	{
-		for(actNode = nodeList.begin(); actNode != nodeList.end(); actNode++)
+		for(actNode = nodeList.begin(); actNode != nodeList.end(); ++actNode)
 		{
 			if(params.getParam(actNode->first, name))
 			{

--- a/src/materials/roughglass.cc
+++ b/src/materials/roughglass.cc
@@ -226,7 +226,7 @@ material_t* roughGlassMat_t::factory(paraMap_t &params, std::list< paraMap_t > &
 	
 	if(mat->loadNodes(paramList, render))
 	{
-		for(actNode = nodeList.begin(); actNode != nodeList.end(); actNode++)
+		for(actNode = nodeList.begin(); actNode != nodeList.end(); ++actNode)
 		{
 			if(params.getParam(actNode->first, name))
 			{

--- a/src/yafraycore/hashgrid.cc
+++ b/src/yafraycore/hashgrid.cc
@@ -52,7 +52,7 @@ void hashGrid_t::updateGrid()
 
 	//travel the vector to build the Grid
 	std::vector<photon_t>::iterator itr;
-	for(itr = photons.begin(); itr != photons.end(); itr++)
+	for(itr = photons.begin(); itr != photons.end(); ++itr)
 	{
 		point3d_t hashindex  =  ( (*itr).pos - bBox.a) * invcellSize;
 
@@ -92,7 +92,7 @@ unsigned int hashGrid_t::gather(const point3d_t &P, foundPhoton_t *found, unsign
 				if(hashGrid[hv] == NULL) continue;
 
 				std::list<photon_t*>::iterator itr;
-				for(itr = hashGrid[hv]->begin(); itr != hashGrid[hv]->end(); itr++)
+				for(itr = hashGrid[hv]->begin(); itr != hashGrid[hv]->end(); ++itr)
 				{
 					if( ( (*itr)->pos- P).lengthSqr() < sqRadius)
 					{


### PR DESCRIPTION
-Decreased performance. It is more effective to use the prefix form of ++it.
 Replace iterator++ with ++iterator.

Ref: http://www.viva64.com/en/d/0165/print/
