### PR TITLE
Normals in blend material fix (Node 514)

### DIFF
--- a/include/core_api/material.h
+++ b/include/core_api/material.h
@@ -82,7 +82,7 @@ class YAFRAYCORE_EXPORT material_t
 			like texture lookups etc.
 			\param bsdfTypes returns flags for all bsdf components the material has
 		 */
-		virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const = 0;
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const = 0;
 		
 		/*! evaluate the BSDF for the given components.
 				@param types the types of BSDFs to be evaluated (e.g. diffuse only, or diffuse and glossy) */
@@ -147,7 +147,7 @@ class YAFRAYCORE_EXPORT material_t
 	protected:
 		/* small function to apply bump mapping to a surface point 
 			you need to determine the partial derivatives for NU and NV first, e.g. from a shader node */
-		void applyBump(const surfacePoint_t &sp, PFLOAT dfdNU, PFLOAT dfdNV) const;
+        void applyBump(surfacePoint_t &sp, PFLOAT dfdNU, PFLOAT dfdNV) const;
 		
 		BSDF_t bsdfFlags;
 		size_t reqMem; //!< the amount of "temporary" memory required to compute/store surface point specific data

--- a/include/core_api/surface.h
+++ b/include/core_api/surface.h
@@ -75,7 +75,7 @@ struct YAFRAYCORE_EXPORT surfacePoint_t
 	void *origin;
 	
 	// Geometry related
-	mutable vector3d_t N; //!< the shading normal.
+    vector3d_t N; //!< the shading normal.
 	vector3d_t Ng; //!< the geometric normal.
 	vector3d_t orcoNg; //!< the untransformed geometric normal.
 	point3d_t P; //!< the (world) position.
@@ -88,8 +88,8 @@ struct YAFRAYCORE_EXPORT surfacePoint_t
 
 	GFLOAT U; //!< the u texture coord.
 	GFLOAT V; //!< the v texture coord.
-	mutable vector3d_t  NU; //!< second vector building orthogonal shading space with N
-	mutable vector3d_t  NV; //!< third vector building orthogonal shading space with N
+    vector3d_t  NU; //!< second vector building orthogonal shading space with N
+    vector3d_t  NV; //!< third vector building orthogonal shading space with N
 	vector3d_t dPdU; //!< u-axis in world space
 	vector3d_t dPdV; //!< v-axis in world space
 	vector3d_t dSdU; //!< u-axis in shading space (NU, NV, N)
@@ -99,6 +99,8 @@ struct YAFRAYCORE_EXPORT surfacePoint_t
 	//GFLOAT dvdNU;
 	//GFLOAT dvdNV;
 };
+
+surfacePoint_t blend_surface_points(surfacePoint_t const& sp_0, surfacePoint_t const& sp_1, float const alpha);
 
 /*! computes and stores the additional data for surface intersections for
 	differential rays */

--- a/include/materials/blendmat.h
+++ b/include/materials/blendmat.h
@@ -20,7 +20,7 @@ class blendMat_t: public nodeMaterial_t
 	public:
 		blendMat_t(const material_t *m1, const material_t *m2, float blendv);
 		virtual ~blendMat_t();
-		virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;

--- a/include/materials/maskmat.h
+++ b/include/materials/maskmat.h
@@ -13,7 +13,7 @@ class maskMat_t: public nodeMaterial_t
 {
 	public:
 		maskMat_t(const material_t *m1, const material_t *m2, CFLOAT thresh);
-		virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;

--- a/include/materials/roughglass.h
+++ b/include/materials/roughglass.h
@@ -10,7 +10,7 @@ class roughGlassMat_t: public nodeMaterial_t
 {
 	public:
 		roughGlassMat_t(float IOR, color_t filtC, const color_t &srcol, bool fakeS, float alpha, float disp_pow);
-		virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, unsigned int &bsdfTypes) const;
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes) const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W) const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs) const { return 0.f; }
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs) const { return 0.f; }

--- a/include/materials/shinydiff.h
+++ b/include/materials/shinydiff.h
@@ -26,7 +26,7 @@ class shinyDiffuseMat_t: public nodeMaterial_t
     public:
         shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength=0.0, float translucencyStrength=0.0, float mirrorStrength=0.0, float emitStrength=0.0, float transmitFilterStrength=1.0);
         virtual ~shinyDiffuseMat_t();
-        virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
         virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const;
         virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
         virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;

--- a/include/utilities/interpolation.h
+++ b/include/utilities/interpolation.h
@@ -26,6 +26,14 @@ __BEGIN_YAFRAY
 
 // Algorithms from: http://local.wasp.uwa.edu.au/~pbourke/miscellaneous/interpolation/
 
+template <typename T>
+inline static T lerp(
+        T const& y1, T const& y2,
+        double alpha)
+{
+    return y1 * alpha + y2 * (1.0 - alpha);
+}
+
 inline static double CosineInterpolate(
 		double y1,double y2,
 		double mu)

--- a/include/yafraycore/nodematerial.h
+++ b/include/yafraycore/nodematerial.h
@@ -30,7 +30,7 @@ class YAFRAYCORE_EXPORT nodeMaterial_t: public material_t
 			std::vector<shaderNode_t *>::const_iterator iter, end=nodes.end();
 			for(iter = nodes.begin(); iter!=end; ++iter) (*iter)->eval(stack, state, sp);
 		}
-		void evalBump(nodeStack_t &stack, const renderState_t &state, const surfacePoint_t &sp, const shaderNode_t *bumpS)const;
+        void evalBump(nodeStack_t &stack, const renderState_t &state, surfacePoint_t &sp, const shaderNode_t *bumpS)const;
 		/*! filter out nodes with specific properties */
 		void filterNodes(const std::vector<shaderNode_t *> &input, std::vector<shaderNode_t *> &output, int flags);
 		virtual ~nodeMaterial_t();

--- a/src/materials/blendmat.cc
+++ b/src/materials/blendmat.cc
@@ -66,18 +66,29 @@ inline void blendMat_t::getBlendVal(const renderState_t &state, const surfacePoi
 	ival = std::min(1.f, std::max(0.f, 1.f - val));
 }
 
-void blendMat_t::initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const
+void blendMat_t::initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const
 {
 	void *old_udat = state.userdata;
 	
 	bsdfTypes = BSDF_NONE;
-	
+
+
+    float alpha, inv_alpha;
+    getBlendVal(state, sp, alpha, inv_alpha);
+
+
+    surfacePoint_t sp_0 = sp;
+
 	state.userdata = PTR_ADD(state.userdata, reqMem);
-	mat1->initBSDF(state, sp, mat1Flags);
+    mat1->initBSDF(state, sp_0, mat1Flags);
 	
+    surfacePoint_t sp_1 = sp;
+
 	state.userdata = PTR_ADD(state.userdata, mmem1);
-	mat2->initBSDF(state, sp, mat2Flags);
-	
+    mat2->initBSDF(state, sp_1, mat2Flags);
+
+     sp = blend_surface_points(sp_0, sp_1, inv_alpha);
+
 	bsdfTypes = mat1Flags | mat2Flags;
 	
 	//todo: bump mapping blending

--- a/src/materials/coatedglossy.cc
+++ b/src/materials/coatedglossy.cc
@@ -40,7 +40,7 @@ class coatedGlossyMat_t: public nodeMaterial_t
 {
 	public:
 		coatedGlossyMat_t(const color_t &col, const color_t &dcol, const color_t &mirCol, float reflect, float diff, PFLOAT ior, float expo, bool as_diff);
-		virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
@@ -101,7 +101,7 @@ coatedGlossyMat_t::coatedGlossyMat_t(const color_t &col, const color_t &dcol, co
 	bsdfFlags = cFlags[C_SPECULAR] | cFlags[C_GLOSSY] | cFlags[C_DIFFUSE];
 }
 
-void coatedGlossyMat_t::initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const
+void coatedGlossyMat_t::initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const
 {
 	MDat_t *dat = (MDat_t *)state.userdata;
 	dat->stack = (char*)state.userdata + sizeof(MDat_t);

--- a/src/materials/glass.cc
+++ b/src/materials/glass.cc
@@ -29,7 +29,7 @@ class glassMat_t: public nodeMaterial_t
 {
 	public:
 		glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS);
-		virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, unsigned int &bsdfTypes)const;
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const {return color_t(0.0);}
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const {return 0.f;}
@@ -68,7 +68,7 @@ glassMat_t::glassMat_t(float IOR, color_t filtC, const color_t &srcol, double di
 	}
 }
 
-void glassMat_t::initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const
+void glassMat_t::initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const
 {
 	nodeStack_t stack(state.userdata);
 	if(bumpS) evalBump(stack, state, sp, bumpS);
@@ -349,7 +349,7 @@ class mirrorMat_t: public material_t
 		refCol = rCol * refVal;
 		bsdfFlags = BSDF_SPECULAR;
 	}
-	virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, unsigned int &bsdfTypes)const { bsdfTypes=bsdfFlags; }
+    virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes)const { bsdfTypes=bsdfFlags; }
 	virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const {return color_t(0.0);}
 	virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 	virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo,
@@ -398,7 +398,7 @@ class nullMat_t: public material_t
 {
 	public:
 	nullMat_t() { }
-	virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, unsigned int &bsdfTypes)const { bsdfTypes=BSDF_NONE; }
+    virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes)const { bsdfTypes=BSDF_NONE; }
 	virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const {return color_t(0.0);}
 	virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 	static material_t* factory(paraMap_t &, std::list< paraMap_t > &, renderEnvironment_t &);

--- a/src/materials/glossy_mat.cc
+++ b/src/materials/glossy_mat.cc
@@ -31,7 +31,7 @@ class glossyMat_t: public nodeMaterial_t
 {
 	public:
 		glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diffuse);
-		virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
@@ -79,7 +79,7 @@ glossyMat_t::glossyMat_t(const color_t &col, const color_t &dcol, float reflect,
 	bsdfFlags |= as_diffuse ? (BSDF_DIFFUSE | BSDF_REFLECT) : (BSDF_GLOSSY | BSDF_REFLECT);
 }
 
-void glossyMat_t::initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const
+void glossyMat_t::initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const
 {
 	MDat_t *dat = (MDat_t *)state.userdata;
 	dat->stack = (char*)state.userdata + sizeof(MDat_t);

--- a/src/materials/maskmat.cc
+++ b/src/materials/maskmat.cc
@@ -36,7 +36,7 @@ maskMat_t::maskMat_t(const material_t *m1, const material_t *m2, CFLOAT thresh):
 }
 
 #define PTR_ADD(ptr,sz) ((char*)ptr+(sz))
-void maskMat_t::initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const
+void maskMat_t::initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const
 {
 	nodeStack_t stack(state.userdata);
 	evalNodes(state, sp, allNodes, stack);

--- a/src/materials/roughglass.cc
+++ b/src/materials/roughglass.cc
@@ -41,7 +41,7 @@ roughGlassMat_t::roughGlassMat_t(float IOR, color_t filtC, const color_t &srcol,
 	}
 }
 
-void roughGlassMat_t::initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes) const
+void roughGlassMat_t::initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes) const
 {
 	nodeStack_t stack(state.userdata);
 	if(bumpS) evalBump(stack, state, sp, bumpS);

--- a/src/materials/shinydiff.cc
+++ b/src/materials/shinydiff.cc
@@ -141,7 +141,7 @@ static inline void accumulate(const float *component, float *accum, float Kr)
     accum[3] = component[3] * acc;
 }
 
-void shinyDiffuseMat_t::initBSDF(const renderState_t &state, const surfacePoint_t &sp, BSDF_t &bsdfTypes)const
+void shinyDiffuseMat_t::initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const
 {
     SDDat_t *dat = (SDDat_t *)state.userdata;
     memset(dat, 0, 8*sizeof(float));

--- a/src/materials/simplemats.cc
+++ b/src/materials/simplemats.cc
@@ -37,7 +37,7 @@ class lightMat_t: public material_t
 {
 	public:
 		lightMat_t(color_t lightC, bool ds=false);
-		virtual void initBSDF(const renderState_t &state, const surfacePoint_t &sp, unsigned int &bsdfTypes) const { bsdfTypes=bsdfFlags; }
+        virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes) const { bsdfTypes=bsdfFlags; }
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs) const {return color_t(0.0);}
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W) const;
 		virtual color_t emit(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo) const;

--- a/src/yafraycore/material.cc
+++ b/src/yafraycore/material.cc
@@ -66,7 +66,7 @@ color_t material_t::getReflectivity(const renderState_t &state, const surfacePoi
 }
 		
 
-void material_t::applyBump(const surfacePoint_t &sp, PFLOAT dfdNU, PFLOAT dfdNV) const
+void material_t::applyBump(surfacePoint_t &sp, PFLOAT dfdNU, PFLOAT dfdNV) const
 {
 	sp.NU += dfdNU * sp.N;
 	sp.NV += dfdNV * sp.N;

--- a/src/yafraycore/nodematerial.cc
+++ b/src/yafraycore/nodematerial.cc
@@ -103,7 +103,7 @@ void nodeMaterial_t::filterNodes(const std::vector<shaderNode_t *> &input, std::
 	}
 }
 
-void nodeMaterial_t::evalBump(nodeStack_t &stack, const renderState_t &state, const surfacePoint_t &sp, const shaderNode_t *bumpS)const
+void nodeMaterial_t::evalBump(nodeStack_t &stack, const renderState_t &state, surfacePoint_t &sp, const shaderNode_t *bumpS)const
 {
 	std::vector<shaderNode_t *>::const_iterator iter, end=bumpNodes.end();
 	for(iter = bumpNodes.begin(); iter!=end; ++iter) (*iter)->evalDerivative(stack, state, sp);

--- a/src/yafraycore/surface.cc
+++ b/src/yafraycore/surface.cc
@@ -1,5 +1,6 @@
 #include <core_api/surface.h>
 #include <core_api/ray.h>
+#include <utilities/interpolation.h>
 
 __BEGIN_YAFRAY
 
@@ -76,6 +77,22 @@ void spDifferentials_t::refractedRay(const diffRay_t &in, diffRay_t &out, PFLOAT
 PFLOAT spDifferentials_t::projectedPixelArea()
 {
 	return (dPdx ^ dPdy).length();
+}
+
+surfacePoint_t blend_surface_points(surfacePoint_t const& sp_0, surfacePoint_t const& sp_1, float const alpha)
+{
+    surfacePoint_t sp_result(sp_0);
+
+    sp_result.N = lerp(sp_0.N, sp_1.N, alpha);
+
+    sp_result.NU = lerp(sp_0.NU, sp_1.NU, alpha);
+    sp_result.NV = lerp(sp_0.NV, sp_1.NV, alpha);
+    sp_result.dPdU = lerp(sp_0.dPdU, sp_1.dPdU, alpha);
+    sp_result.dPdV = lerp(sp_0.dPdV, sp_1.dPdV, alpha);
+    sp_result.dSdU = lerp(sp_0.dSdU, sp_1.dSdU, alpha);
+    sp_result.dSdV = lerp(sp_0.dSdV, sp_1.dSdV, alpha);
+
+    return sp_result;
 }
 
 __END_YAFRAY


### PR DESCRIPTION
- Bug fixed in the blend material that caused normals to not be blended (Bug node 514)
- Also const-corrected surfacePoint_t (removed all mutables and removed const from functions where needed)
