### PR TITLE
- Camera clipping corrected using planes (Node 505)

### DIFF
--- a/include/cameras/angularCamera.h
+++ b/include/cameras/angularCamera.h
@@ -16,8 +16,9 @@ class angularCam_t: public camera_t
 {
 	public:
 		angularCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
-				   int _resx, int _resy, PFLOAT aspect, PFLOAT angle, bool circ);
-		virtual void setAxis(const vector3d_t &vx, const vector3d_t &vy, const vector3d_t &vz);
+                     int _resx, int _resy, PFLOAT aspect, PFLOAT angle, bool circ,
+                     float const near_clip_distance = 0.0f, float const far_clip_distance = 1e6f);
+        virtual void setAxis(const vector3d_t &vx, const vector3d_t &vy, const vector3d_t &vz);
 		virtual ray_t shootRay(PFLOAT px, PFLOAT py, float lu, float lv, PFLOAT &wt) const;
 		virtual point3d_t screenproject(const point3d_t &p) const;
 		

--- a/include/cameras/architectCamera.h
+++ b/include/cameras/architectCamera.h
@@ -12,10 +12,10 @@ class renderEnvironment_t;
 class architectCam_t: public perspectiveCam_t
 {
 	public:
-		architectCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
-			int _resx, int _resy, PFLOAT aspect=1,
-			PFLOAT df=1, PFLOAT ap=0, PFLOAT dofd=0, bokehType bt=BK_DISK1, bkhBiasType bbt=BB_NONE,
-			PFLOAT bro=0);
+        architectCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
+                       int _resx, int _resy, PFLOAT aspect=1,
+                       PFLOAT df=1, PFLOAT ap=0, PFLOAT dofd=0, bokehType bt=BK_DISK1, bkhBiasType bbt=BB_NONE, PFLOAT bro=0,
+                       float const near_clip_distance = 0.0f, float const far_clip_distance = 1e6f);
 		virtual ~architectCam_t();
 		virtual void setAxis(const vector3d_t &vx, const vector3d_t &vy, const vector3d_t &vz);
 		virtual point3d_t screenproject(const point3d_t &p) const;

--- a/include/cameras/orthographicCamera.h
+++ b/include/cameras/orthographicCamera.h
@@ -15,7 +15,8 @@ class orthoCam_t: public camera_t
 {
 	public:
 		orthoCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
-				   int _resx, int _resy, PFLOAT aspect, PFLOAT scale);
+                   int _resx, int _resy, PFLOAT aspect, PFLOAT scale,
+                   float const near_clip_distance = 0.0f, float const far_clip_distance = 1e6f);
 		virtual void setAxis(const vector3d_t &vx, const vector3d_t &vy, const vector3d_t &vz);
 		virtual ray_t shootRay(PFLOAT px, PFLOAT py, float lu, float lv, PFLOAT &wt) const;
 		virtual point3d_t screenproject(const point3d_t &p) const;

--- a/include/cameras/perspectiveCamera.h
+++ b/include/cameras/perspectiveCamera.h
@@ -14,14 +14,15 @@ class renderEnvironment_t;
 
 class perspectiveCam_t: public camera_t
 {
-	public:
+    public:
 		enum bokehType {BK_DISK1, BK_DISK2, BK_TRI=3, BK_SQR, BK_PENTA, BK_HEXA, BK_RING};
-		enum bkhBiasType {BB_NONE, BB_CENTER, BB_EDGE};
-		perspectiveCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
-			int _resx, int _resy, PFLOAT aspect=1,
-			PFLOAT df=1, PFLOAT ap=0, PFLOAT dofd=0, bokehType bt=BK_DISK1, bkhBiasType bbt=BB_NONE, PFLOAT bro=0);
-		virtual ~perspectiveCam_t();
-		virtual void setAxis(const vector3d_t &vx, const vector3d_t &vy, const vector3d_t &vz);
+        enum bkhBiasType {BB_NONE, BB_CENTER, BB_EDGE};
+        perspectiveCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
+                         int _resx, int _resy, PFLOAT aspect=1,
+                         PFLOAT df=1, PFLOAT ap=0, PFLOAT dofd=0, bokehType bt=BK_DISK1, bkhBiasType bbt=BB_NONE, PFLOAT bro=0,
+                         float const near_clip_distance = 0.0f, float const far_clip_distance = 1e6f);
+        virtual ~perspectiveCam_t();
+        virtual void setAxis(const vector3d_t &vx, const vector3d_t &vy, const vector3d_t &vz);
 		virtual ray_t shootRay(PFLOAT px, PFLOAT py, float lu, float lv, PFLOAT &wt) const;
 		virtual bool sampleLense() const;
 		virtual point3d_t screenproject(const point3d_t &p) const;

--- a/include/core_api/camera.h
+++ b/include/core_api/camera.h
@@ -25,7 +25,8 @@
 
 #include <yafray_config.h>
 
-#include "ray.h"
+#include <core_api/ray.h>
+#include <utilities/geometry.h>
 
 __BEGIN_YAFRAY
 
@@ -37,8 +38,8 @@ class YAFRAYCORE_EXPORT camera_t
 {
 	public:
 		camera_t() { }
-		camera_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up, int _resx, int _resy, float aspect)
-		:position(pos), resx(_resx), resy(_resy), aspect_ratio(aspect * (PFLOAT)resy / (PFLOAT)resx)
+        camera_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up, int _resx, int _resy, float aspect, float const near_clip_distance, float const far_clip_distance) :
+            position(pos), resx(_resx), resy(_resy), aspect_ratio(aspect * (PFLOAT)resy / (PFLOAT)resx)
 		{
 			// Calculate and store camera axis
 			camY = up - position;
@@ -48,8 +49,14 @@ class YAFRAYCORE_EXPORT camera_t
 			camX.normalize();
 			camY.normalize();
 			camZ.normalize();
+
+            near_plane.n = camZ;
+            near_plane.p = vector3d_t(position) + camZ * near_clip_distance;
+
+            far_plane.n = camZ;
+            far_plane.p = vector3d_t(position) + camZ * far_clip_distance;
 		}
-		virtual ~camera_t() {};
+        virtual ~camera_t() {}
 		virtual void setAxis(const vector3d_t &vx, const vector3d_t &vy, const vector3d_t &vz) = 0; //!< Set camera axis
 		/*! Shoot a new ray from the camera gived image pixel coordinates px,py and lense dof effect */
 		virtual ray_t shootRay(PFLOAT px, PFLOAT py, float u, float v, PFLOAT &wt) const = 0; //!< Shoot a new ray from the camera.
@@ -80,7 +87,7 @@ class YAFRAYCORE_EXPORT camera_t
 		
 		float aspect_ratio;	//<! Aspect ratio of camera (not image in pixel units!)
 
-        float nearClippingDistance, farClippingDistance;
+        Plane near_plane, far_plane;
 };
 
 __END_YAFRAY

--- a/include/utilities/geometry.h
+++ b/include/utilities/geometry.h
@@ -1,0 +1,24 @@
+#ifndef GEOMETRY_H
+#define GEOMETRY_H
+
+#include <yafray_constants.h>
+
+#include <core_api/vector3d.h>
+#include <core_api/ray.h>
+
+__BEGIN_YAFRAY
+
+struct Plane
+{
+    vector3d_t p;
+    vector3d_t n;
+};
+
+inline float ray_plane_intersection(ray_t const& ray, Plane const& plane)
+{
+    return plane.n * (plane.p - vector3d_t(ray.from)) / (ray.dir * plane.n);
+}
+
+__END_YAFRAY
+
+#endif // GEOMETRY_H

--- a/src/cameras/angularCamera.cc
+++ b/src/cameras/angularCamera.cc
@@ -26,8 +26,9 @@
 __BEGIN_YAFRAY
 
 angularCam_t::angularCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
-			int _resx, int _resy, PFLOAT asp, PFLOAT angle, bool circ)
-			:camera_t(pos, look, up, _resx, _resy, asp),hor_phi(angle*M_PI/180.f), circular(circ)
+                           int _resx, int _resy, PFLOAT asp, PFLOAT angle, bool circ,
+                           float const near_clip_distance, float const far_clip_distance) :
+    camera_t(pos, look, up, _resx, _resy, asp, near_clip_distance, far_clip_distance), hor_phi(angle*M_PI/180.f), circular(circ)
 {
 	// Initialize camera specific plane coordinates
 	setAxis(camX,camY,camZ);
@@ -62,8 +63,8 @@ ray_t angularCam_t::shootRay(PFLOAT px, PFLOAT py, float lu, float lv, PFLOAT &w
 	//PFLOAT sp = sin(phi);
 	ray.dir = fSin(phi)*(fCos(theta)*vright + fSin(theta)*vup ) + fCos(phi)*vto;
 
-    ray.tmin = nearClippingDistance;
-    ray.tmax = farClippingDistance;
+    ray.tmin = ray_plane_intersection(ray, near_plane);
+    ray.tmax = ray_plane_intersection(ray, far_plane);
 
 	return ray;
 }
@@ -90,11 +91,9 @@ camera_t* angularCam_t::factory(paraMap_t &params, renderEnvironment_t &render)
     params.getParam("nearClip", nearClip);
     params.getParam("farClip", farClip);
 	
-	angularCam_t *cam = new angularCam_t(from, to, up, resx, resy, aspect, angle, circular);
+    angularCam_t *cam = new angularCam_t(from, to, up, resx, resy, aspect, angle, circular, nearClip, farClip);
 	if(mirrored) cam->vright *= -1.0;
 	cam->max_r = max_angle/angle;
-    cam->nearClippingDistance = nearClip;
-    cam->farClippingDistance = farClip;
 	
 	return cam;
 }

--- a/src/cameras/architectCamera.cc
+++ b/src/cameras/architectCamera.cc
@@ -27,8 +27,8 @@ __BEGIN_YAFRAY
 
 architectCam_t::architectCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
 		int _resx, int _resy, PFLOAT aspect,
-		PFLOAT df, PFLOAT ap, PFLOAT dofd, bokehType bt, bkhBiasType bbt, PFLOAT bro)
-		:perspectiveCam_t(pos, look, up, _resx, _resy, aspect, df, ap, dofd, bt, bbt, bro)
+        PFLOAT df, PFLOAT ap, PFLOAT dofd, bokehType bt, bkhBiasType bbt, PFLOAT bro, float const near_clip_distance, float const far_clip_distance)
+        :perspectiveCam_t(pos, look, up, _resx, _resy, aspect, df, ap, dofd, bt, bbt, bro, near_clip_distance, far_clip_distance)
 {
 	// Initialize camera specific plane coordinates
 	setAxis(camX,camY,camZ);
@@ -125,10 +125,7 @@ camera_t* architectCam_t::factory(paraMap_t &params, renderEnvironment_t &render
 	bkhBiasType bbt = BB_NONE;
 	if (*bkhbias=="center") 		bbt = BB_CENTER;
 	else if (*bkhbias=="edge") 		bbt = BB_EDGE;
-    architectCam_t* cam = new architectCam_t(from, to, up, resx, resy, aspect, dfocal, apt, dofd, bt, bbt, bkhrot);
-
-    cam->nearClippingDistance = nearClip;
-    cam->farClippingDistance = farClip;
+    architectCam_t* cam = new architectCam_t(from, to, up, resx, resy, aspect, dfocal, apt, dofd, bt, bbt, bkhrot, nearClip, farClip);
 
     return cam;
 }

--- a/src/cameras/orthographicCamera.cc
+++ b/src/cameras/orthographicCamera.cc
@@ -26,8 +26,8 @@
 __BEGIN_YAFRAY
 
 orthoCam_t::orthoCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
-		int _resx, int _resy, PFLOAT aspect, PFLOAT _scale)
-		:camera_t(pos, look, up, _resx, _resy, aspect), scale(_scale)
+        int _resx, int _resy, PFLOAT aspect, PFLOAT _scale, float const near_clip_distance, float const far_clip_distance)
+        :camera_t(pos, look, up, _resx, _resy, aspect, near_clip_distance, far_clip_distance), scale(_scale)
 {
 	// Initialize camera specific plane coordinates
 	setAxis(camX,camY,camZ);
@@ -55,8 +55,8 @@ ray_t orthoCam_t::shootRay(PFLOAT px, PFLOAT py, float lu, float lv, PFLOAT &wt)
 	ray.from = pos + vright*px + vup*py;
 	ray.dir = vto;
 
-    ray.tmin = nearClippingDistance;
-    ray.tmax = farClippingDistance;
+    ray.tmin = ray_plane_intersection(ray, near_plane);
+    ray.tmax = ray_plane_intersection(ray, far_plane);
 
 	return ray;
 }
@@ -95,10 +95,7 @@ camera_t* orthoCam_t::factory(paraMap_t &params, renderEnvironment_t &render)
     params.getParam("nearClip", nearClip);
     params.getParam("farClip", farClip);
 
-    orthoCam_t* cam = new orthoCam_t(from, to, up, resx, resy, aspect, scale);
-
-    cam->nearClippingDistance = nearClip;
-    cam->farClippingDistance = farClip;
+    orthoCam_t* cam = new orthoCam_t(from, to, up, resx, resy, aspect, scale, nearClip, farClip);
 
     return cam;
 }

--- a/src/cameras/perspectiveCamera.cc
+++ b/src/cameras/perspectiveCamera.cc
@@ -26,9 +26,10 @@
 __BEGIN_YAFRAY
 
 perspectiveCam_t::perspectiveCam_t(const point3d_t &pos, const point3d_t &look, const point3d_t &up,
-		int _resx, int _resy, PFLOAT aspect,
-		PFLOAT df, PFLOAT ap, PFLOAT dofd, bokehType bt, bkhBiasType bbt, PFLOAT bro)
-		:camera_t(pos, look, up,  _resx, _resy, aspect), bkhtype(bt), bkhbias(bbt), aperture(ap) , focal_distance(df), dof_distance(dofd)
+                                   int _resx, int _resy, PFLOAT aspect,
+                                   PFLOAT df, PFLOAT ap, PFLOAT dofd, bokehType bt, bkhBiasType bbt, PFLOAT bro,
+                                   float const near_clip_distance, float const far_clip_distance) :
+    camera_t(pos, look, up,  _resx, _resy, aspect, near_clip_distance, far_clip_distance), bkhtype(bt), bkhbias(bbt), aperture(ap) , focal_distance(df), dof_distance(dofd)
 {
 	// Initialize camera specific plane coordinates
 	setAxis(camX,camY,camZ);
@@ -121,6 +122,8 @@ void perspectiveCam_t::getLensUV(PFLOAT r1, PFLOAT r2, PFLOAT &u, PFLOAT &v) con
 	}
 }
 
+
+
 ray_t perspectiveCam_t::shootRay(PFLOAT px, PFLOAT py, float lu, float lv, PFLOAT &wt) const
 {
 	ray_t ray;
@@ -130,8 +133,8 @@ ray_t perspectiveCam_t::shootRay(PFLOAT px, PFLOAT py, float lu, float lv, PFLOA
 	ray.dir = vright*px + vup*py + vto;
 	ray.dir.normalize();
 
-    ray.tmin = nearClippingDistance;
-    ray.tmax = farClippingDistance;
+    ray.tmin = ray_plane_intersection(ray, near_plane);
+    ray.tmax = ray_plane_intersection(ray, far_plane);
 
 	if (aperture!=0) {
 		PFLOAT u, v;
@@ -221,10 +224,7 @@ camera_t* perspectiveCam_t::factory(paraMap_t &params, renderEnvironment_t &rend
 	if (*bkhbias=="center") 		bbt = BB_CENTER;
 	else if (*bkhbias=="edge") 		bbt = BB_EDGE;
 
-    perspectiveCam_t* cam = new perspectiveCam_t(from, to, up, resx, resy, aspect, dfocal, apt, dofd, bt, bbt, bkhrot);
-
-    cam->nearClippingDistance = nearClip;
-    cam->farClippingDistance = farClip;
+    perspectiveCam_t* cam = new perspectiveCam_t(from, to, up, resx, resy, aspect, dfocal, apt, dofd, bt, bbt, bkhrot, nearClip, farClip);
 
     return cam;
 }


### PR DESCRIPTION
See title, tested with all camera types, results for perspective and ortho identical with Blender GL and render. For the angular camera, the planes actually becomes curves as well, but that is the nature of this stuff. ;-)
