### PR TITLE
Fixed hangs and memory leak in Linux

### DIFF
--- a/src/yafraycore/ccthreads.cc
+++ b/src/yafraycore/ccthreads.cc
@@ -229,6 +229,7 @@ void thread_t::wait()
 thread_t::~thread_t()
 {
 	if(running) wait();
+	else pthread_join(id,NULL);
 }
 #elif defined( WIN32_THREADS )
 DWORD WINAPI wrapper (void *data)


### PR DESCRIPTION
To fix issue: http://www.yafaray.org/node/318

In Linux, when using multiple threads, the missing pthread_join line caused memory leak and eventually filled up the thread stack, causing EAGAIN errors in newly created threads and therefore a complete hang of Yafaray and Blender after rendering several frames.
