### PR TITLE
Improve Glass internal reflection

### DIFF
--- a/src/materials/glass.cc
+++ b/src/materials/glass.cc
@@ -233,7 +233,7 @@ void glassMat_t::getSpecular(const renderState_t &state, const surfacePoint_t &s
 		else refr = false; // in this case, we need to sample dispersion, i.e. not considered specular
 		// accounting for fresnel reflection when leaving refractive material is a real performance
 		// killer as rays keep bouncing inside objects and contribute little after few bounces, so limit we it:
-		if(outside || state.raylevel < 2)
+		if(outside || state.raylevel < 3)
 		{
 			dir[0] = wo;
 			dir[0].reflect(N);


### PR DESCRIPTION
Fixes issue: http://www.yafaray.org/node/569

Increasing the internal limit for glass internal reflection gives more realistic detail in glass. As discussed with DarkTide, it will cause a small performance penalty, but the added realism is worth it and the performance penalty is not so big.
