### PR TITLE
New params for Background Transparency

### DIFF
--- a/include/core_api/mcintegrator.h
+++ b/include/core_api/mcintegrator.h
@@ -66,6 +66,8 @@ class YAFRAYCORE_EXPORT mcIntegrator_t: public tiledIntegrator_t
 		int nPaths; //! Number of samples for mc raytracing
 		int maxBounces; //! Max. path depth for mc raytracing
 		std::vector<light_t*> lights; //! An array containing all the scene lights
+		bool transpBackground; //! Render background as transparent
+		bool transpRefractedBackground; //! Render refractions of background as transparent
 };
 
 __END_YAFRAY


### PR DESCRIPTION
To fix issue: http://www.yafaray.org/node/468

New parameters added in the Render Tab to control the Background Transparency. These parameters have been applied to the Direct Lighting, Photon Mapping, SPPM and Path Tracing integrators. I did not change yet Bidir and Debug.

The new parameters are:
- Transp. Background: (true by default for backwards compatibility). When true, it renders the background as transparent. When false, it renders the background as opaque.
- Materials Transp. Refraction: (true by default for backwards compatibility). When true, the refractions of a transparent background are also transparent. When false, the refractions of a transparent background show the background as if it were opaque.
