### PR TITLE
Fixes for Black Dots

### DIFF
--- a/include/core_api/texture.h
+++ b/include/core_api/texture.h
@@ -33,7 +33,7 @@ inline void angmap(const point3d_t &p, PFLOAT &u, PFLOAT &v)
 	u = v = 0.f;
 	if (r > 0.f)
 	{
-		float phiRatio = M_1_PI * acos(p.y);//[0,1] range
+		float phiRatio = M_1_PI * fAcos(p.y);//[0,1] range
 		r = phiRatio / fSqrt(r);
 		u = p.x * r;// costheta * r * phiRatio
 		v = p.z * r;// sintheta * r * phiRatio
@@ -65,12 +65,12 @@ inline void spheremap(const point3d_t &p, PFLOAT &u, PFLOAT &v)
 	
 	if(sqrtRPhi > 0.f)
 	{
-		if(p.y < 0.f) phiRatio = (M_2PI - acos(p.x / fSqrt(sqrtRPhi))) * M_1_2PI;
-		else		  phiRatio = acos(p.x / fSqrt(sqrtRPhi)) * M_1_2PI;
+		if(p.y < 0.f) phiRatio = (M_2PI - fAcos(p.x / fSqrt(sqrtRPhi))) * M_1_2PI;
+		else		  phiRatio = fAcos(p.x / fSqrt(sqrtRPhi)) * M_1_2PI;
 		u = 1.f - phiRatio;
 	}
 	
-	v = 1.f - (acos(p.z / fSqrt(sqrtRTheta)) * M_1_PI);
+	v = 1.f - (fAcos(p.z / fSqrt(sqrtRTheta)) * M_1_PI);
 }
 
 // maps u,v coords in the 0..1 interval to a direction

--- a/include/utilities/mathOptimizations.h
+++ b/include/utilities/mathOptimizations.h
@@ -60,6 +60,8 @@ __BEGIN_YAFRAY
 #define M_1_2PI		0.15915494309189533577 // 1 / (2 * PI)
 #define M_4_PI		1.27323954473516268615 // 4 / PI
 #define M_4_PI2		0.40528473456935108578 // 4 / PI ^ 2
+#define M_MINUS_PI	-3.14159265358979323846	/* -pi */
+#define M_MINUS_PI_2		-1.57079632679489661923	/* -pi/2 */
 
 #define degToRad(deg) (deg * 0.01745329251994329576922)  // deg * PI / 180
 #define radToDeg(rad) (rad * 57.29577951308232087684636) // rad * 180 / PI
@@ -236,6 +238,55 @@ inline float fTan(float x)
 	return tan(x);
 #endif
 }
+
+inline float fAcos(float x)
+{
+#ifdef FAST_TRIG
+	return acosf(x);  //no domain checks, acosf instead of acos as the variable is float
+#else
+	//checks if variable gets out of domain for some reason, you get the range limit instead of NaN
+	if(x<=-1.0) return(M_PI);
+	else if(x>=1.0) return(0.0);
+	else return acosf(x);  //acosf instead of acos as the variable is float
+#endif
+}
+
+inline double fAcos(double x)
+{
+#ifdef FAST_TRIG
+	return acos(x);  //no domain checks, acos as the variable is double
+#else
+	//checks if variable gets out of domain for some reason, you get the range limit instead of NaN
+	if(x<=-1.0) return(M_PI);
+	else if(x>=1.0) return(0.0);
+	else return acos(x);  //no domain checks, acos as the variable is double
+#endif
+}
+
+inline float fAsin(float x)
+{
+#ifdef FAST_TRIG
+	return asinf(x);  //no domain checks, asinf instead of asin as the variable is float
+#else
+	//checks if variable gets out of domain for some reason, you get the range limit instead of NaN
+	if(x<=-1.0) return(M_MINUS_PI_2);	
+	else if(x>=1.0) return(M_PI_2);
+	else return asinf(x);  //asinf instead of asin as the variable is float
+#endif
+}
+
+inline double fAsin(double x)
+{
+#ifdef FAST_TRIG
+	return asin(x);  //no domain checks, asin as the variable is double
+#else
+	//checks if variable gets out of domain for some reason, you get the range limit instead of NaN
+	if(x<=-1.0) return(M_MINUS_PI_2);	
+	else if(x>=1.0) return(M_PI_2);
+	else return asin(x);  //no domain checks, asin as the variable is double
+#endif
+}
+
 __END_YAFRAY
 
 #endif

--- a/include/yafraycore/photon.h
+++ b/include/yafraycore/photon.h
@@ -29,7 +29,7 @@ class dirConverter_t
 		}
 		std::pair<unsigned char,unsigned char> convert(const vector3d_t &dir)
 		{
-			int t=(int)(acos(dir.z)*c255Ratio);
+			int t=(int)(fAcos(dir.z)*c255Ratio);
 			int p=(int)(atan2(dir.y,dir.x)*c256Ratio);
 			if(t>254) t=254;
 			else if(t<0) t=0;

--- a/src/backgrounds/darksky.cc
+++ b/src/backgrounds/darksky.cc
@@ -71,7 +71,7 @@ darkSkyBackground_t::darkSkyBackground_t(const point3d_t dir, float turb, float 
 	sunDir.z += alt;
 	sunDir.normalize();
 
-	thetaS = acos(sunDir.z);
+	thetaS = fAcos(sunDir.z);
 
 	act = (nightSky)?"ON":"OFF";
 	Y_INFO << "DarkSky: Night mode [ " << act << " ]" << yendl;
@@ -222,7 +222,7 @@ inline color_t darkSkyBackground_t::getSkyCol(const ray_t &ray) const
 
 	cosGamma = Iw * sunDir;
     cosGamma2 = cosGamma * cosGamma;
-	gamma = acos(cosGamma);
+	gamma = fAcos(cosGamma);
 
 	x = PerezFunction(perez_x, cosTheta, gamma, cosGamma2, zenith_x);
 	y = PerezFunction(perez_y, cosTheta, gamma, cosGamma2, zenith_y);
@@ -312,7 +312,7 @@ background_t *darkSkyBackground_t::factory(paraMap_t &params,renderEnvironment_t
 	darkSkyBackground_t *darkSky = new darkSkyBackground_t(dir, turb, power, bright, clamp, av, bv, cv, dv, ev,
 																altitude, night, exp, gammaEnc, colorS);
 
-	if (add_sun && radToDeg(acos(dir.z)) < 100.0)
+	if (add_sun && radToDeg(fAcos(dir.z)) < 100.0)
 	{
 		vector3d_t d(dir);
 		d.normalize();

--- a/src/backgrounds/sunsky.cc
+++ b/src/backgrounds/sunsky.cc
@@ -60,7 +60,7 @@ sunskyBackground_t::sunskyBackground_t(const point3d_t dir, float turb, float a_
 {
 	sunDir.set(dir.x, dir.y, dir.z);
 	sunDir.normalize();
-	thetaS = acos(sunDir.z);
+	thetaS = fAcos(sunDir.z);
 	theta2 = thetaS*thetaS;
 	theta3 = theta2*thetaS;
 	phiS = atan2(sunDir.y, sunDir.x);
@@ -132,7 +132,7 @@ double sunskyBackground_t::AngleBetween(double thetav, double phiv) const
   double cospsi = fSin(thetav) * fSin(thetaS) * fCos(phiS-phiv) + fCos(thetav) * fCos(thetaS);
   if (cospsi > 1)  return 0;
   if (cospsi < -1) return M_PI;
-  return acos(cospsi);
+  return fAcos(cospsi);
 }
 
 inline color_t sunskyBackground_t::getSkyCol(const ray_t &ray) const
@@ -144,7 +144,7 @@ inline color_t sunskyBackground_t::getSkyCol(const ray_t &ray) const
 
 	color_t skycolor(0.0);
 
-	theta = acos(Iw.z);
+	theta = fAcos(Iw.z);
 	if (theta>(0.5*M_PI)) {
 		// this stretches horizon color below horizon, must be possible to do something better...
 		// to compensate, simple fade to black
@@ -244,7 +244,7 @@ background_t *sunskyBackground_t::factory(paraMap_t &params,renderEnvironment_t 
 	
 	if (add_sun)
 	{
-		color_t suncol = ComputeAttenuatedSunlight(acos(std::fabs(dir.z)), turb);//(*new_sunsky)(vector3d_t(dir.x, dir.y, dir.z));
+		color_t suncol = ComputeAttenuatedSunlight(fAcos(std::fabs(dir.z)), turb);//(*new_sunsky)(vector3d_t(dir.x, dir.y, dir.z));
 		double angle = 0.27;
 		double cosAngle = cos(degToRad(angle));
 		float invpdf = (2.f * M_PI * (1.f - cosAngle));

--- a/src/integrators/SkyIntegrator.cc
+++ b/src/integrators/SkyIntegrator.cc
@@ -181,7 +181,7 @@ class YAFRAYPLUGIN_EXPORT SkyIntegrator : public volumeIntegrator_t {
 				color_t L_s = background->eval(bgray, false);
 				float b_r_angular = b_r * 3 / (2 * M_PI * 8) * (1.0f + (w * (-ray.dir)) * (w * (-ray.dir)));
 				float K = 0.67f;
-				float angle = acos(w * (ray.dir));
+				float angle = fAcos(w * (ray.dir));
 				float b_m_angular = b_m / (2 * K * M_PI) * mieScatter(angle);
 				//std::cout << "w: " << w << " theta: " << theta << " -ray.dir: " << -ray.dir << " angle: " << angle << " mie ang " << b_m_angular << std::endl;
 				S0_m = S0_m + colorA_t(L_s) * b_m_angular;

--- a/src/lights/iesLight.cc
+++ b/src/lights/iesLight.cc
@@ -96,14 +96,14 @@ iesLight_t::iesLight_t(const point3d_t &from, const point3d_t &to, const color_t
 
 void iesLight_t::getAngles(float &u, float &v, const vector3d_t &dir, const float &costheta) const
 {
-	u = (dir.z >= 1.f) ? 0.f : radToDeg(acos(dir.z));
+	u = (dir.z >= 1.f) ? 0.f : radToDeg(fAcos(dir.z));
 	
 	if(dir.y < 0)
 	{
 		u = 360.f - u;
 	}
 	
-	v = (costheta >= 1.f) ? 0.f : radToDeg(acos(costheta));
+	v = (costheta >= 1.f) ? 0.f : radToDeg(fAcos(costheta));
 }
 
 bool iesLight_t::illuminate(const surfacePoint_t &sp, color_t &col, ray_t &wi) const

--- a/src/textures/basicnodes.cc
+++ b/src/textures/basicnodes.cc
@@ -60,7 +60,7 @@ inline point3d_t spheremap(const point3d_t &p)
 	if (d>0) {
 		res.z = fSqrt(d);
 		if ((p.x!=0) && (p.y!=0)) res.x = -atan2(p.x, p.y) * M_1_PI;
-		res.y = 1.0f - 2.0f*(acos(p.z/res.z) * M_1_PI);
+		res.y = 1.0f - 2.0f*(fAcos(p.z/res.z) * M_1_PI);
 	}
 	return res;
 }

--- a/src/yafraycore/std_primitives.cc
+++ b/src/yafraycore/std_primitives.cc
@@ -65,7 +65,7 @@ void sphere_t::getSurface(surfacePoint_t &sp, const point3d_t &hit, intersectDat
 	sp.P = hit;
 	createCS(sp.N, sp.NU, sp.NV);
 	sp.U = atan2(normal.y, normal.x)*M_1_PI + 1;
-	sp.V = 1.f - acos(normal.z)*M_1_PI;
+	sp.V = 1.f - fAcos(normal.z)*M_1_PI;
 	sp.light = 0;
 }
 

--- a/src/yafraycore/vector3d.cc
+++ b/src/yafraycore/vector3d.cc
@@ -206,7 +206,7 @@ vector3d_t discreteVectorCone(const vector3d_t &dir, PFLOAT cangle, int sample, 
 	PFLOAT r1=(PFLOAT)(sample / square)/(PFLOAT)square;
 	PFLOAT r2=(PFLOAT)(sample % square)/(PFLOAT)square;
 	PFLOAT tt = M_2PI * r1;
-	PFLOAT ss = acos(1.0 - (1.0 - cangle)*r2);
+	PFLOAT ss = fAcos(1.0 - (1.0 - cangle)*r2);
 	vector3d_t	vx(fCos(ss),fSin(ss)*fCos(tt),fSin(ss)*fSin(tt));
 	vector3d_t	i(1,0,0),c;
 	matrix4x4_t M(1);


### PR DESCRIPTION
This fixes several Black Dots situations where NaN appear in the color calculations. Apparently this can be caused by two circumstances:
- Usage of 32bit float numbers within 64bit double acos() functions.
- Sometimes, for some reason, the input to the acos() function is very slightly outside of the [-1,1] domain, causing a NaN. Perhaps that could be caused by the normal accumulative 32bit float calculation errors?

Therefore, I have done several modifications in the Core code to use, instead of the standard double acos() funcion, an inline fAcos() function defined both as a float and as a double, depending on the type of number being used.
- I have also added runtime-checks of the domain validity. If the input number is outside the domain, it's considered as being at the end of the domain. For example, -1.0001 would be considered as -1.0 for the acos calculation.
- I have used acosf() instead of acos() for the 32bit floating point numbers. That also caused problems when the input 32bit number was at the exremes of the domain.
