### PR TITLE
Fixed hangs and crashes in Linux

### DIFF
--- a/src/yafraycore/ccthreads.cc
+++ b/src/yafraycore/ccthreads.cc
@@ -213,6 +213,7 @@ void thread_t::run()
 {
 	pthread_attr_init(&attr);
 	pthread_attr_setdetachstate(&attr,PTHREAD_CREATE_JOINABLE);
+	pthread_attr_setstacksize(&attr,1048576); //To mitigate crashes/segfaults in Linux. Still not perfect, we need to find the cause of the pthread stack overflows, specially in Photon Mapping.
 	pthread_create(&id,&attr,wrapper,this);
 	running=true;
 }
@@ -229,6 +230,7 @@ void thread_t::wait()
 thread_t::~thread_t()
 {
 	if(running) wait();
+	else pthread_join(id,NULL); //To fix complete hangs in blender-yafaray after rendering several frames in Linux systems.
 }
 #elif defined( WIN32_THREADS )
 DWORD WINAPI wrapper (void *data)


### PR DESCRIPTION
To fix issue: http://www.yafaray.org/node/318

In Linux, when using multiple threads, the missing pthread_join line caused memory leak and eventually filled up the thread stack, causing EAGAIN errors in newly created threads and therefore a complete hang of Yafaray and Blender after rendering several frames.

Still with that fix, Photon Mapping still caused random crashes and segfaults, so I have increased the pthread stack size and it seems to have solved the issue.
