### PR TITLE
Fixes for Black and White Dots

### DIFF
--- a/include/core_api/texture.h
+++ b/include/core_api/texture.h
@@ -33,7 +33,7 @@ inline void angmap(const point3d_t &p, PFLOAT &u, PFLOAT &v)
 	u = v = 0.f;
 	if (r > 0.f)
 	{
-		float phiRatio = M_1_PI * acos(p.y);//[0,1] range
+		float phiRatio = M_1_PI * fAcos(p.y);//[0,1] range
 		r = phiRatio / fSqrt(r);
 		u = p.x * r;// costheta * r * phiRatio
 		v = p.z * r;// sintheta * r * phiRatio
@@ -65,12 +65,12 @@ inline void spheremap(const point3d_t &p, PFLOAT &u, PFLOAT &v)
 	
 	if(sqrtRPhi > 0.f)
 	{
-		if(p.y < 0.f) phiRatio = (M_2PI - acos(p.x / fSqrt(sqrtRPhi))) * M_1_2PI;
-		else		  phiRatio = acos(p.x / fSqrt(sqrtRPhi)) * M_1_2PI;
+		if(p.y < 0.f) phiRatio = (M_2PI - fAcos(p.x / fSqrt(sqrtRPhi))) * M_1_2PI;
+		else		  phiRatio = fAcos(p.x / fSqrt(sqrtRPhi)) * M_1_2PI;
 		u = 1.f - phiRatio;
 	}
 	
-	v = 1.f - (acos(p.z / fSqrt(sqrtRTheta)) * M_1_PI);
+	v = 1.f - (fAcos(p.z / fSqrt(sqrtRTheta)) * M_1_PI);
 }
 
 // maps u,v coords in the 0..1 interval to a direction

--- a/include/utilities/mathOptimizations.h
+++ b/include/utilities/mathOptimizations.h
@@ -60,18 +60,28 @@ __BEGIN_YAFRAY
 #define M_1_2PI		0.15915494309189533577 // 1 / (2 * PI)
 #define M_4_PI		1.27323954473516268615 // 4 / PI
 #define M_4_PI2		0.40528473456935108578 // 4 / PI ^ 2
+#define M_MINUS_PI	-3.14159265358979323846	/* -pi */
+#define M_MINUS_PI_2		-1.57079632679489661923	/* -pi/2 */
 
 #define degToRad(deg) (deg * 0.01745329251994329576922)  // deg * PI / 180
 #define radToDeg(rad) (rad * 57.29577951308232087684636) // rad * 180 / PI
 
+//FIXME: All the overloaded double definitions have been added to fix the "white dots" problems and they seem to work fine. However several of them should be refined in the future to include constants with the correct precision for the doubles calculations.
+
 #define POLYEXP(x) (float)(x * (x * (x * (x * (x * 1.8775767e-3f + 8.9893397e-3f) + 5.5826318e-2f) + 2.4015361e-1f) + 6.9315308e-1f) + 9.9999994e-1f)
 #define POLYLOG(x) (float)(x * (x * (x * (x * (x * -3.4436006e-2f + 3.1821337e-1f) + -1.2315303f) + 2.5988452) + -3.3241990f) + 3.1157899f)
+#define POLYEXP_DOUBLE(x) (double)(x * (x * (x * (x * (x * 1.8775767e-3f + 8.9893397e-3f) + 5.5826318e-2f) + 2.4015361e-1f) + 6.9315308e-1f) + 9.9999994e-1f)
+#define POLYLOG_DOUBLE(x) (double)(x * (x * (x * (x * (x * -3.4436006e-2f + 3.1821337e-1f) + -1.2315303f) + 2.5988452) + -3.3241990f) + 3.1157899f)
 
 #define f_HI 129.00000f
 #define f_LOW -126.99999f
+#define f_HI_DOUBLE 129.000000000000000
+#define f_LOW_DOUBLE -126.999999999999999
 
 #define LOG_EXP 0x7F800000
 #define LOG_MANT 0x7FFFFF
+#define LOG_EXP_DOUBLE 0x7F800000
+#define LOG_MANT_DOUBLE 0x7FFFFF
 
 #define CONST_P 0.225f
 
@@ -79,6 +89,12 @@ union bitTwiddler
 {
 	int i;
 	float f;
+};
+
+union bitTwiddler_double
+{
+	long i;
+	double f;
 };
 
 inline float fExp2(float x)
@@ -96,6 +112,21 @@ inline float fExp2(float x)
 	return (expipart.f * POLYEXP(fpart.f));
 }
 
+inline double fExp2(double x)
+{
+	bitTwiddler_double ipart, fpart;
+	bitTwiddler_double expipart;
+
+	x = std::min(x, f_HI_DOUBLE);
+	x = std::max(x, f_LOW_DOUBLE);
+
+	ipart.i = (int)(x - 0.5);
+	fpart.f = (x - (double)(ipart.i));
+	expipart.i = ((ipart.i + 127) << 23);
+
+	return (expipart.f * POLYEXP_DOUBLE(fpart.f));
+}
+
 inline float fLog2(float x)
 {
 	bitTwiddler one, i, m, e;
@@ -108,9 +139,45 @@ inline float fLog2(float x)
 	return (POLYLOG(m.f) * (m.f - one.f) + e.f);
 }
 
+inline double fLog2(double x)
+{
+	bitTwiddler_double one, i, m, e;
+
+	one.f = 1.0;
+	i.f = x;
+	e.f = (double)(((i.i & LOG_EXP_DOUBLE) >> 23) - 127);
+	m.i = ((i.i & LOG_MANT_DOUBLE) | one.i);
+
+	return (POLYLOG_DOUBLE(m.f) * (m.f - one.f) + e.f);
+}
+
 inline float asmSqrt(float n)
 {
     float r = n;
+#ifdef _MSC_VER
+    __asm
+    {
+		fld r
+		fsqrt
+		fstp r
+    }
+#elif __GNUC__
+    asm(
+		"fld %0;"
+		"fsqrt;"
+		"fstp %0"
+		:"=m" (r)
+		:"m" (r)
+		);
+#else
+    r = fsqrt(n);
+#endif
+    return r;
+}
+
+inline double asmSqrt(double n)
+{
+    double r = n;
 #ifdef _MSC_VER
     __asm
     {
@@ -143,7 +210,27 @@ inline float iSqrt(float x)
     return a.f*(1.5f - xhalf*a.f*a.f);
 }
 
+inline double iSqrt(double x)
+{
+    bitTwiddler_double a;
+    double xhalf = 0.5 * x;
+
+    a.f = x;
+    a.i = 0x5f3759df - (a.i>>1);
+
+    return a.f*(1.5 - xhalf*a.f*a.f);
+}
+
 inline float fPow(float a, float b)
+{
+#ifdef FAST_MATH
+	return fExp2(fLog2(a) * b);
+#else
+	return pow(a,b);
+#endif
+}
+
+inline double fPow(double a, double b)
 {
 #ifdef FAST_MATH
 	return fExp2(fLog2(a) * b);
@@ -155,7 +242,16 @@ inline float fPow(float a, float b)
 inline float fLog(float a)
 {
 #ifdef FAST_MATH
-	return fLog2(a) * M_LN2;
+	return fLog2(a) * (float) M_LN2;
+#else
+	return log(a);
+#endif
+}
+
+inline double fLog(double a)
+{
+#ifdef FAST_MATH
+	return fLog2(a) * (double) M_LN2;
 #else
 	return log(a);
 #endif
@@ -170,6 +266,15 @@ inline float fExp(float a)
 #endif
 }
 
+inline double fExp(double a)
+{
+#ifdef FAST_MATH
+	return fExp2((double)M_LOG2E * a);
+#else
+	return exp(a);
+#endif
+}
+
 inline float fISqrt(float a)
 {
 #ifdef FAST_MATH
@@ -179,7 +284,25 @@ inline float fISqrt(float a)
 #endif
 }
 
+inline double fISqrt(double a)
+{
+#ifdef FAST_MATH
+	return iSqrt(a);
+#else
+	return 1.0/sqrt(a);
+#endif
+}
+
 inline float fSqrt(float a)
+{
+#ifdef FAST_MATH
+	return asmSqrt(a);
+#else
+	return sqrt(a);
+#endif
+}
+
+inline double fSqrt(double a)
 {
 #ifdef FAST_MATH
 	return asmSqrt(a);
@@ -198,8 +321,18 @@ inline float fLdexp(float x, int a)
 #endif
 }
 
-inline float fSin(float x)
+inline double fLdexp(double x, int a)
 {
+#ifdef FAST_MATH
+	//return x * fPow(2.0, a);
+	return ldexp(x, a);
+#else
+	return ldexp(x, a);
+#endif
+}
+
+inline float fSin(float x)
+{ 
 #ifdef FAST_TRIG
 	if(x > M_2PI || x < -M_2PI) x -= ((int)(x * (float)M_1_2PI)) * (float)M_2PI; //float modulo x % M_2PI
 	if(x < -M_PI)
@@ -212,8 +345,35 @@ inline float fSin(float x)
 	}
 
 	x = ((float)M_4_PI * x) - ((float)M_4_PI2 * x * std::fabs(x));
-	return CONST_P * (x * std::fabs(x) - x) + x;
+	float result = CONST_P * (x * std::fabs(x) - x) + x;
+  //Make sure that the function is in the valid range [-1.0,+1.0]
+	if(result <= -1.0) return -1.0f;
+	else if(result >= 1.0) return 1.0f;
+	else return result;
+#else
+	return sin(x);
+#endif
+}
 
+inline double fSin(double x)
+{
+#ifdef FAST_TRIG
+	if(x > M_2PI || x < -M_2PI) x -= ((int)(x * (double)M_1_2PI)) * (double)M_2PI; //double modulo x % M_2PI
+	if(x < -M_PI)
+	{
+		x += (double)M_2PI;
+	}
+	else if(x > M_PI)
+	{
+		x -= (double)M_2PI;
+	}
+
+	x = ((double)M_4_PI * x) - ((double)M_4_PI2 * x * std::fabs(x));
+	double result = CONST_P * (x * std::fabs(x) - x) + x;
+	//Make sure that the function is in the valid range [-1.0,+1.0]
+	if(result <= -1.0) return -1.0;
+	else if(result >= 1.0) return 1.0;
+	else return result;
 #else
 	return sin(x);
 #endif
@@ -228,14 +388,67 @@ inline float fCos(float x)
 #endif
 }
 
+inline double fCos(double x)
+{
+#ifdef FAST_TRIG
+	return fSin(x + (double)M_PI_2);
+#else
+	return cos(x);
+#endif
+}
+
 inline float fTan(float x)
 {
 #ifdef FAST_TRIG
+  //FIXME: We should consider the case when fCos(x)=0.0 to avoid Inf numbers.
+	return fSin(x) / fCos(x); 
+#else
+	return tan(x);
+#endif
+}
+
+inline double fTan(double x)
+{
+#ifdef FAST_TRIG
+  //FIXME: We should consider the case when fCos(x)=0.0 to avoid Inf numbers.
 	return fSin(x) / fCos(x);
 #else
 	return tan(x);
 #endif
 }
+
+inline float fAcos(float x)
+{
+	//checks if variable gets out of domain [-1.0,+1.0], so you get the range limit instead of NaN
+	if(x<=-1.0) return((float)M_PI);
+	else if(x>=1.0) return(0.0);
+	else return acos(x);
+}
+
+inline double fAcos(double x)
+{
+	//checks if variable gets out of domain [-1.0,+1.0], so you get the range limit instead of NaN
+	if(x<=-1.0) return(M_PI);
+	else if(x>=1.0) return(0.0);
+	else return acos(x);
+}
+
+inline float fAsin(float x)
+{
+	//checks if variable gets out of domain [-1.0,+1.0], so you get the range limit instead of NaN
+	if(x<=-1.0) return((float)M_MINUS_PI_2);	
+	else if(x>=1.0) return((float)M_PI_2);
+	else return asin(x);
+}
+
+inline double fAsin(double x)
+{
+	//checks if variable gets out of domain [-1.0,+1.0], so you get the range limit instead of NaN
+	if(x<=-1.0) return(M_MINUS_PI_2);	
+	else if(x>=1.0) return(M_PI_2);
+	else return asin(x);
+}
+
 __END_YAFRAY
 
 #endif

--- a/include/utilities/sample_utils.h
+++ b/include/utilities/sample_utils.h
@@ -102,6 +102,7 @@ class pdf1D_t
 		// Find surrounding cdf segments
 		float *ptr = std::lower_bound(cdf, cdf+count+1, u);
 		int index = (int) (ptr-cdf-1);
+		if(index<0) index=0; //FIXME: this is one of the fixes for the white dots. Sometimes for some reason this index was -1, causing an access outside the array and an invalid value->NaN, inf, etc. Now, we ensure the index does not move <0, but we should look for a better solution to prevent the index to go <0 in the first place.
 		// Return offset along current cdf segment
 		float delta = (u - cdf[index]) / (cdf[index+1] - cdf[index]);
 		if(pdf) *pdf = func[index] * invIntegral;

--- a/include/yafraycore/photon.h
+++ b/include/yafraycore/photon.h
@@ -29,7 +29,7 @@ class dirConverter_t
 		}
 		std::pair<unsigned char,unsigned char> convert(const vector3d_t &dir)
 		{
-			int t=(int)(acos(dir.z)*c255Ratio);
+			int t=(int)(fAcos(dir.z)*c255Ratio);
 			int p=(int)(atan2(dir.y,dir.x)*c256Ratio);
 			if(t>254) t=254;
 			else if(t<0) t=0;

--- a/src/backgrounds/darksky.cc
+++ b/src/backgrounds/darksky.cc
@@ -71,7 +71,7 @@ darkSkyBackground_t::darkSkyBackground_t(const point3d_t dir, float turb, float 
 	sunDir.z += alt;
 	sunDir.normalize();
 
-	thetaS = acos(sunDir.z);
+	thetaS = fAcos(sunDir.z);
 
 	act = (nightSky)?"ON":"OFF";
 	Y_INFO << "DarkSky: Night mode [ " << act << " ]" << yendl;
@@ -222,7 +222,7 @@ inline color_t darkSkyBackground_t::getSkyCol(const ray_t &ray) const
 
 	cosGamma = Iw * sunDir;
     cosGamma2 = cosGamma * cosGamma;
-	gamma = acos(cosGamma);
+	gamma = fAcos(cosGamma);
 
 	x = PerezFunction(perez_x, cosTheta, gamma, cosGamma2, zenith_x);
 	y = PerezFunction(perez_y, cosTheta, gamma, cosGamma2, zenith_y);
@@ -312,7 +312,7 @@ background_t *darkSkyBackground_t::factory(paraMap_t &params,renderEnvironment_t
 	darkSkyBackground_t *darkSky = new darkSkyBackground_t(dir, turb, power, bright, clamp, av, bv, cv, dv, ev,
 																altitude, night, exp, gammaEnc, colorS);
 
-	if (add_sun && radToDeg(acos(dir.z)) < 100.0)
+	if (add_sun && radToDeg(fAcos(dir.z)) < 100.0)
 	{
 		vector3d_t d(dir);
 		d.normalize();

--- a/src/backgrounds/sunsky.cc
+++ b/src/backgrounds/sunsky.cc
@@ -60,7 +60,7 @@ sunskyBackground_t::sunskyBackground_t(const point3d_t dir, float turb, float a_
 {
 	sunDir.set(dir.x, dir.y, dir.z);
 	sunDir.normalize();
-	thetaS = acos(sunDir.z);
+	thetaS = fAcos(sunDir.z);
 	theta2 = thetaS*thetaS;
 	theta3 = theta2*thetaS;
 	phiS = atan2(sunDir.y, sunDir.x);
@@ -132,7 +132,7 @@ double sunskyBackground_t::AngleBetween(double thetav, double phiv) const
   double cospsi = fSin(thetav) * fSin(thetaS) * fCos(phiS-phiv) + fCos(thetav) * fCos(thetaS);
   if (cospsi > 1)  return 0;
   if (cospsi < -1) return M_PI;
-  return acos(cospsi);
+  return fAcos(cospsi);
 }
 
 inline color_t sunskyBackground_t::getSkyCol(const ray_t &ray) const
@@ -144,7 +144,7 @@ inline color_t sunskyBackground_t::getSkyCol(const ray_t &ray) const
 
 	color_t skycolor(0.0);
 
-	theta = acos(Iw.z);
+	theta = fAcos(Iw.z);
 	if (theta>(0.5*M_PI)) {
 		// this stretches horizon color below horizon, must be possible to do something better...
 		// to compensate, simple fade to black
@@ -244,7 +244,7 @@ background_t *sunskyBackground_t::factory(paraMap_t &params,renderEnvironment_t 
 	
 	if (add_sun)
 	{
-		color_t suncol = ComputeAttenuatedSunlight(acos(std::fabs(dir.z)), turb);//(*new_sunsky)(vector3d_t(dir.x, dir.y, dir.z));
+		color_t suncol = ComputeAttenuatedSunlight(fAcos(std::fabs(dir.z)), turb);//(*new_sunsky)(vector3d_t(dir.x, dir.y, dir.z));
 		double angle = 0.27;
 		double cosAngle = cos(degToRad(angle));
 		float invpdf = (2.f * M_PI * (1.f - cosAngle));

--- a/src/integrators/SkyIntegrator.cc
+++ b/src/integrators/SkyIntegrator.cc
@@ -181,7 +181,7 @@ class YAFRAYPLUGIN_EXPORT SkyIntegrator : public volumeIntegrator_t {
 				color_t L_s = background->eval(bgray, false);
 				float b_r_angular = b_r * 3 / (2 * M_PI * 8) * (1.0f + (w * (-ray.dir)) * (w * (-ray.dir)));
 				float K = 0.67f;
-				float angle = acos(w * (ray.dir));
+				float angle = fAcos(w * (ray.dir));
 				float b_m_angular = b_m / (2 * K * M_PI) * mieScatter(angle);
 				//std::cout << "w: " << w << " theta: " << theta << " -ray.dir: " << -ray.dir << " angle: " << angle << " mie ang " << b_m_angular << std::endl;
 				S0_m = S0_m + colorA_t(L_s) * b_m_angular;

--- a/src/lights/iesLight.cc
+++ b/src/lights/iesLight.cc
@@ -96,14 +96,14 @@ iesLight_t::iesLight_t(const point3d_t &from, const point3d_t &to, const color_t
 
 void iesLight_t::getAngles(float &u, float &v, const vector3d_t &dir, const float &costheta) const
 {
-	u = (dir.z >= 1.f) ? 0.f : radToDeg(acos(dir.z));
+	u = (dir.z >= 1.f) ? 0.f : radToDeg(fAcos(dir.z));
 	
 	if(dir.y < 0)
 	{
 		u = 360.f - u;
 	}
 	
-	v = (costheta >= 1.f) ? 0.f : radToDeg(acos(costheta));
+	v = (costheta >= 1.f) ? 0.f : radToDeg(fAcos(costheta));
 }
 
 bool iesLight_t::illuminate(const surfacePoint_t &sp, color_t &col, ray_t &wi) const

--- a/src/textures/basicnodes.cc
+++ b/src/textures/basicnodes.cc
@@ -60,7 +60,7 @@ inline point3d_t spheremap(const point3d_t &p)
 	if (d>0) {
 		res.z = fSqrt(d);
 		if ((p.x!=0) && (p.y!=0)) res.x = -atan2(p.x, p.y) * M_1_PI;
-		res.y = 1.0f - 2.0f*(acos(p.z/res.z) * M_1_PI);
+		res.y = 1.0f - 2.0f*(fAcos(p.z/res.z) * M_1_PI);
 	}
 	return res;
 }

--- a/src/yafraycore/std_primitives.cc
+++ b/src/yafraycore/std_primitives.cc
@@ -65,7 +65,7 @@ void sphere_t::getSurface(surfacePoint_t &sp, const point3d_t &hit, intersectDat
 	sp.P = hit;
 	createCS(sp.N, sp.NU, sp.NV);
 	sp.U = atan2(normal.y, normal.x)*M_1_PI + 1;
-	sp.V = 1.f - acos(normal.z)*M_1_PI;
+	sp.V = 1.f - fAcos(normal.z)*M_1_PI;
 	sp.light = 0;
 }
 

--- a/src/yafraycore/vector3d.cc
+++ b/src/yafraycore/vector3d.cc
@@ -206,7 +206,7 @@ vector3d_t discreteVectorCone(const vector3d_t &dir, PFLOAT cangle, int sample, 
 	PFLOAT r1=(PFLOAT)(sample / square)/(PFLOAT)square;
 	PFLOAT r2=(PFLOAT)(sample % square)/(PFLOAT)square;
 	PFLOAT tt = M_2PI * r1;
-	PFLOAT ss = acos(1.0 - (1.0 - cangle)*r2);
+	PFLOAT ss = fAcos(1.0 - (1.0 - cangle)*r2);
 	vector3d_t	vx(fCos(ss),fSin(ss)*fCos(tt),fSin(ss)*fSin(tt));
 	vector3d_t	i(1,0,0),c;
 	matrix4x4_t M(1);


### PR DESCRIPTION
For your information, I have found the cause of many of the black and white dots problems. I've tested this with the "horror gallery" scenes and it seems to work fine with both Linux 32 bits and Linux 64 bits
## BLACK DOTS (NaN)

The problem is located in the acos() function used in several places of the program. The acos() is the arccosine and its valid domain is [-1.0, +1.0]

However, sometimes it receives values "slightly" outside the domain, as for example +1.000000000000000001

That causes the acos() function to generate an invalid NaN result that is propagated over all the math until you get the black NaN dots in the render.

I have created a custom fAcos() function which does a domain check before calling the actual acos(), ensuring that the values are within the domain. If a value is outside the domain, it's "forced" inside.

The underlying causes of the "values outside the domain" are quite complex and surprising. It also explains why this is different in Linux 32 bits and Linux 64 bits, for example.

Some of the causes:
- The compilation flags are "unsafe". This is good for speed, but many floating point operations are not guaranteed to be done correctly. However, we have to keep the unsafe flags or we would have a much slower yafaray, so we do the extra checks manually in yafaray.
- Linux x86 (32 bits) compiles by default by using the CPU x87 floating point operations. Those operations are not IEEE 754 compliant. In fact, the x87 floating point operations use ALWAYS 80 bits for the x87 internal registers. That's why even with float 32bits numbers you may get some "garbage" digits where you would not expect them. Doing the manual domain checks should mitigate this, or even resolve it.
- Linux x86_64 (64 bits) compiles by default by using the CPU SSE floating point operations and NOT the x87 for floating point operations. These are IEEE 754 complaint and their internal registers work as expected (32bits with floats and 64 bits with doubles). Therefore, the floating point operations may work differently in Linux with 64 bits than 32 bits causing the strange differences in the Horror Gallery. In any case, even using SSE you still have sometimes values outside the valid domain, so the manual domain checks should mitigate or resolve this.
## WHITE DOTS (Inf or very big values)
- In the pdf1D class in sample_utils.h, sometimes one array index was -1 causing an access to array out of bounds and therefore causing eventually invalid values, NaNs, Infs, etc. This is the line causing the problem

int index = (int) (ptr-cdf-1);

So I have added this fix:

int index = (int) (ptr-cdf-1);
if(index<0) index=0;  <-- Fix to make sure the index never goes to negative values outside the array.

However, this should be investigated in the future to see why the index goes to -1 in the first place.
- Other type of white dots problem happens when the CMake option FAST_MATH=ON

One of the reasons is that the math simplifications were written only for float 32bit numbers, but in the rest of the program they sometimes were used to calculate double 64bit numbers, resulting in bad calculations and white dots.
- Also, sometimes the fSin() function generated return values outside its valid range [-1.0,+1.0] also causing other white dots.

I have created the double 64bit versions of all optimizations. I have also added checks to make sure the fSin() return value is in the correct range.

However, I think that we need to refine a bit better the double 64bit versions of the optimizations, but it seems to work fine now anyway.

For your reference, it's possible to force the compilation to use x87 or SSE instructions. For example, in Linux 32 bits, you can get the same results you get in a Linux 64 bits by compiling with the gcc flags: -msse2 -mfpmath=sse

I suppose these fixes will not solve all the black/white dots problems, but I hope they help in most cases.

Best regards!  David Bluecame.
