### PR TITLE
Fixed hangs and crashes in Linux

### DIFF
--- a/src/yafraycore/ccthreads.cc
+++ b/src/yafraycore/ccthreads.cc
@@ -213,17 +213,15 @@ void thread_t::run()
 {
 	pthread_attr_init(&attr);
 	pthread_attr_setdetachstate(&attr,PTHREAD_CREATE_JOINABLE);
+	pthread_attr_setstacksize(&attr,1048576); //A bigger stack size helps to avoid crashes when you use many simultaneous threads.
 	pthread_create(&id,&attr,wrapper,this);
 	running=true;
 }
 
 void thread_t::wait()
 {
-	if(running)
-	{
-		pthread_join(id,NULL);
-		running=false;
-	}
+	pthread_join(id,NULL);
+	running=false;
 }
 
 thread_t::~thread_t()

--- a/src/yafraycore/integrator.cc
+++ b/src/yafraycore/integrator.cc
@@ -188,7 +188,7 @@ bool tiledIntegrator_t::renderPass(int samples, int offset, bool adaptive)
 		}
 		tc.countCV.unlock();
 		//join all threads (although they probably have exited already, but not necessarily):
-		for(int i=0;i<nthreads;++i) delete workers[i];
+		for(int i=0;i<nthreads;++i) {workers[i]->wait(); delete workers[i];} //Fix for Linux hangs/crashes, it's better to wait for threads to end before deleting the thread objects. Using code to wait for the threads to end in the destructors is not recommended.
 	}
 	else
 	{


### PR DESCRIPTION
To fix issue: http://www.yafaray.org/node/318

*\* Needs to be tested in Windows systems **

The problem in Linux was that threads that had already ended (running=0) were not joined, so their resources were not released and eventually the stack was full.

However, we cannot use the pthreads_join in the thread object destructor, as the object could be destroyed before the thread is ended and joined.

So, I had to change the code in integrator.cc so, instead of just deleting the thread objects, first we have to wait and then destroy. This could affect Windows systems, so testing is advised to ensure they are ok.

I had also to modify the thread wait() function to ensure the thread is joined regardless is running or not.
