### PR TITLE
linux hangs fix update for the experimental branch blackdots

### DIFF
--- a/src/yafraycore/ccthreads.cc
+++ b/src/yafraycore/ccthreads.cc
@@ -213,24 +213,20 @@ void thread_t::run()
 {
 	pthread_attr_init(&attr);
 	pthread_attr_setdetachstate(&attr,PTHREAD_CREATE_JOINABLE);
-	pthread_attr_setstacksize(&attr,1048576); //To mitigate crashes/segfaults in Linux. Still not perfect, we need to find the cause of the pthread stack overflows, specially in Photon Mapping.
+	pthread_attr_setstacksize(&attr,1048576); //A bigger stack size helps to avoid crashes when you use many simultaneous threads.
 	pthread_create(&id,&attr,wrapper,this);
 	running=true;
 }
 
 void thread_t::wait()
 {
-	if(running)
-	{
-		pthread_join(id,NULL);
-		running=false;
-	}
+	pthread_join(id,NULL);
+	running=false;
 }
 
 thread_t::~thread_t()
 {
 	if(running) wait();
-	else pthread_join(id,NULL); //To fix complete hangs in blender-yafaray after rendering several frames in Linux systems.
 }
 #elif defined( WIN32_THREADS )
 DWORD WINAPI wrapper (void *data)

--- a/src/yafraycore/integrator.cc
+++ b/src/yafraycore/integrator.cc
@@ -188,7 +188,7 @@ bool tiledIntegrator_t::renderPass(int samples, int offset, bool adaptive)
 		}
 		tc.countCV.unlock();
 		//join all threads (although they probably have exited already, but not necessarily):
-		for(int i=0;i<nthreads;++i) delete workers[i];
+		for(int i=0;i<nthreads;++i) {workers[i]->wait(); delete workers[i];} //Fix for Linux hangs/crashes, it's better to wait for threads to end before deleting the thread objects. Using code to wait for the threads to end in the destructors is not recommended.
 	}
 	else
 	{


### PR DESCRIPTION
Better solution for the Linux hangs and crashes that avoids sporadic crashes to preview due to double joins.

It works fine in Linux 32 bits and 64 bits, but I had to modify a common Windows-Linux part of the code, so it should be tested in Windows as soon as possible to ensure it does not cause problems there.
