### PR TITLE
Allow building for Windows 7 and 8.1 (64 bits) for Blender 2.73 using Mi...

### DIFF
--- a/include/core_api/color.h
+++ b/include/core_api/color.h
@@ -29,6 +29,16 @@
 
 #define COLOR_SIZE 3
 
+// ensure isnan and isinf are available. I *hope* it works with OSX w. gcc 4.x too
+#ifdef _MSC_VER
+#include <float.h>
+#define isnan _isnan
+#define isinf _isinf
+#else
+using std::isnan; // from cmath
+using std::isinf; // from cmath
+#endif
+
 __BEGIN_YAFRAY
 
 class YAFRAYCORE_EXPORT color_t

--- a/include/integrators/sppm.h
+++ b/include/integrators/sppm.h
@@ -18,6 +18,7 @@
 #include <utilities/mcqmc.h>
 #include <yafraycore/scr_halton.h>
 #include <yafraycore/hashgrid.h>
+#include <stdint.h>
 
 __BEGIN_YAFRAY
 

--- a/src/yafraycore/yafsystem.cc
+++ b/src/yafraycore/yafsystem.cc
@@ -143,7 +143,8 @@ const std::list<std::string> & listDir(const std::string &dir)
     if (pattern[i] == '/') pattern[i] = '\\';
 
   _finddata_t    FindData;
-  int            hFind, Result;
+  intptr_t       hFind;
+  int			 Result;
 
   hFind = _findfirst(pattern.c_str(), &FindData);
   if (hFind != -1)


### PR DESCRIPTION
...nGW64

 Changes to be committed:
	modified:   include/core_api/color.h   (to allow building)
	modified:   include/integrators/sppm.h (to allow building)
	modified:   src/yafraycore/yafsystem.cc  (to avoid crash when loading plugins)

 Untracked files:
	CMakeConfig/UserConfig.txt  (basically changing it to use Python 3.4)