### PR TITLE
 Fix for Volumetric artifacts and wrong Alpha

### DIFF
--- a/src/yafraycore/integrator.cc
+++ b/src/yafraycore/integrator.cc
@@ -297,8 +297,8 @@ bool tiledIntegrator_t::renderTile(renderArea_t &a, int n_samples, int offset, b
 				colorA_t colIntegration = integrate(rstate, c_ray); // L_o
 				colorA_t colVolTransmittance = scene->volIntegrator->transmittance(rstate, c_ray); // T
 				colorA_t colVolIntegration = scene->volIntegrator->integrate(rstate, c_ray); // L_v
-                colVolIntegration.A = 1.f-colVolTransmittance.A; //Fix for Volumetrics Alpha artifacts. For the Alpha of the volume itself, I will use the inverse of the Aplha calculated by the transmittance calculation. It seems to give good results for volumes rendered on top of other objects, volumes rendered on top of an opaque background and volumes rendered on top of transparent background (for later compositing). 
-                colorA_t col = (colIntegration*colVolTransmittance)+colVolIntegration;
+				colVolIntegration.A = 1.f-colVolTransmittance.A; //Fix for Volumetrics Alpha artifacts. For the Alpha of the volume itself, I will use the inverse of the Aplha calculated by the transmittance calculation. It seems to give good results for volumes rendered on top of other objects, volumes rendered on top of an opaque background and volumes rendered on top of transparent background (for later compositing). 
+				colorA_t col = (colIntegration*colVolTransmittance)+colVolIntegration;
 				imageFilm->addSample(wt * col, j, i, dx, dy, &a);
 
 				if(do_depth)


### PR DESCRIPTION
These changes try to fix the following problems that happen when using Volumetrics in current YafaRay v0.1.5:
* When rendering over other objects, artifacts due to Alpha > 1.0
* When rendering over an opaque background, artifacts due to Alpha > 1.0
* When rendering over a transparent background, Alpha is 1.0 in all the volume and the boundary cube, making it impossible to do composition of volumes.

For some example files before and after the fix, see:
https://github.com/DavidBluecame/YafaRay---unofficial-Builds/raw/master/YafaRay%20volumetrics%20fix%20-%20example%20files.zip

 Changes to be committed:
	modified:   src/yafraycore/integrator.cc