### PR TITLE
Fix for exception in yafaray-xml when xstart or ystart are not zero.

### DIFF
--- a/src/xml_loader/xml-loader.cc
+++ b/src/xml_loader/xml-loader.cc
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
 
 	if(ih)
 	{
-		out = new imageOutput_t(ih, outputPath, bx, by);
+		out = new imageOutput_t(ih, outputPath, 0, 0);
 		if(!out) return 1;				
 	}
 	else return 1;


### PR DESCRIPTION
I have tested this fix and it seems to work fine. No exceptions happen when I select now a xstart or ystart. Now, when rendering into Blender/to image I get the same result image section as saving XML and rendering it with yafaray-xml.

The only problem I have with my fix is that I don't quite understand yet why the problem happened in the first place or why this fix works, but it seems to work...

 Changes to be committed:
	modified:   src/xml_loader/xml-loader.cc