### PR TITLE
Fix for negated color in negated Musgrave/Voronoi textures

### DIFF
--- a/src/textures/layernode.cc
+++ b/src/textures/layernode.cc
@@ -62,8 +62,13 @@ void layerNode_t::eval(nodeStack_t &stack, const renderState_t &state, const sur
 	{
 		if(!TEX_RGB)	texcolor = default_col;
 		else			Tin = Ta;
+        
+        CFLOAT Tin_non_negative;
+        
+        if(Tin<0.f) Tin_non_negative = 0.f;
+        else Tin_non_negative = Tin;
 		
-		rcol = texture_rgb_blend(texcolor, rcol, Tin, stencilTin * colfac, mode);
+		rcol = texture_rgb_blend(texcolor, rcol, Tin_non_negative, stencilTin * colfac, mode);
 		rcol.clampRGB0();
 	}
 	

--- a/src/textures/layernode.cc
+++ b/src/textures/layernode.cc
@@ -63,12 +63,13 @@ void layerNode_t::eval(nodeStack_t &stack, const renderState_t &state, const sur
 		if(!TEX_RGB)	texcolor = default_col;
 		else			Tin = Ta;
         
-        CFLOAT Tin_non_negative;
+        CFLOAT Tin_truncated_range;
         
-        if(Tin<0.f) Tin_non_negative = 0.f;
-        else Tin_non_negative = Tin;
+        if(Tin>1.f) Tin_truncated_range=1.f;
+        else if(Tin<0.f) Tin_truncated_range=0.f;
+        else Tin_truncated_range = Tin;
 		
-		rcol = texture_rgb_blend(texcolor, rcol, Tin_non_negative, stencilTin * colfac, mode);
+		rcol = texture_rgb_blend(texcolor, rcol, Tin_truncated_range, stencilTin * colfac, mode);
 		rcol.clampRGB0();
 	}
 	


### PR DESCRIPTION
When the Musgrave texture is mapped to the material color and the texture is inverted, negative values are passed to the color causing a negation in the color as well. That also happens in Voronoi textures when they are negated and have a high intensity scale. I've truncated any negative values from the texture before they are used for color generation. This loses negative values for color, but I think this is what should be expected acording to the bug http://www.yafaray.org/node/187 ?

 Changes to be committed:
	modified:   src/textures/layernode.cc