### PR TITLE
Expose Shadow Bias to users to avoid black dots in wrong self shadow

### DIFF
--- a/include/core_api/scene.h
+++ b/include/core_api/scene.h
@@ -206,6 +206,8 @@ class YAFRAYCORE_EXPORT scene_t
 
 		std::vector<light_t *> lights;
 		volumeIntegrator_t *volIntegrator;
+        float raydist_min_bias;
+        float shadow_bias;
 
 	protected:
 

--- a/src/integrators/SingleScatterIntegrator.cc
+++ b/src/integrators/SingleScatterIntegrator.cc
@@ -95,7 +95,7 @@ public:
 								if( (*l)->diracLight() )
 								{
 									bool ill = (*l)->illuminate(sp, lcol, lightRay);
-									lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is bad.
+									lightRay.tmin = scene->shadow_bias; // < better add some _smart_ self-bias value...this is bad.
 									if (lightRay.tmax < 0.f) lightRay.tmax = 1e10; // infinitely distant light
 
 									// transmittance from the point p in the volume to the light (i.e. how much light reaches p)
@@ -124,7 +124,7 @@ public:
 										ls.s2 = 0.5f; //(*state.prng)();
 
 										(*l)->illumSample(sp, ls, lightRay);
-										lightRay.tmin = YAF_SHADOW_BIAS;
+										lightRay.tmin = scene->shadow_bias;
 										if (lightRay.tmax < 0.f) lightRay.tmax = 1e10; // infinitely distant light
 
 										// transmittance from the point p in the volume to the light (i.e. how much light reaches p)
@@ -168,7 +168,7 @@ public:
 				if( (*l)->illuminate(sp, lcol, lightRay) )
 				{
 					// ...shadowed...
-					lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is bad.
+					lightRay.tmin = scene->shadow_bias; // < better add some _smart_ self-bias value...this is bad.
 					if (lightRay.tmax < 0.f) lightRay.tmax = 1e10; // infinitely distant light
 					bool shadowed = scene->isShadowed(state, lightRay);
 					if (!shadowed)
@@ -225,7 +225,7 @@ public:
 					if((*l)->illumSample(sp, ls, lightRay))
 					{
 						// ...shadowed...
-						lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is bad.
+						lightRay.tmin = scene->shadow_bias; // < better add some _smart_ self-bias value...this is bad.
 						if (lightRay.tmax < 0.f) lightRay.tmax = 1e10; // infinitely distant light
 						bool shadowed = scene->isShadowed(state, lightRay);
 						if(!shadowed) {

--- a/src/integrators/bidirpath.cc
+++ b/src/integrators/bidirpath.cc
@@ -295,7 +295,7 @@ colorA_t biDirIntegrator_t::integrate(renderState_t &state, diffRay_t &ray) cons
 
 		// sample light (todo!)
 		ray_t lray;
-		lray.tmin = MIN_RAYDIST;
+		lray.tmin = scene->raydist_min_bias;
 		lray.tmax = -1.f;
 		float lightNumPdf;
 		int lightNum = lightPowerD->DSample(prng(), &lightNumPdf);
@@ -479,7 +479,7 @@ int biDirIntegrator_t::createPath(renderState_t &state, ray_t &start, std::vecto
 		v.flags = s.sampledFlags;
 		v.wo = ray.dir;
 		ray.from = v.sp.P;
-		ray.tmin = MIN_RAYDIST;
+		ray.tmin = scene->raydist_min_bias;
 		ray.tmax = -1.f;
 	}
 	++dbg;

--- a/src/integrators/pathtracer.cc
+++ b/src/integrators/pathtracer.cc
@@ -193,7 +193,7 @@ colorA_t pathIntegrator_t::integrate(renderState_t &state, diffRay_t &ray/*, sam
 				throughput = scol;
 				state.includeLights = false;
 
-				pRay.tmin = MIN_RAYDIST;
+				pRay.tmin = scene->raydist_min_bias;
 				pRay.tmax = -1.0;
 				pRay.from = sp.P;
 				
@@ -234,7 +234,7 @@ colorA_t pathIntegrator_t::integrate(renderState_t &state, diffRay_t &ray/*, sam
 					caustic = traceCaustics && (s.sampledFlags & (BSDF_SPECULAR | BSDF_GLOSSY | BSDF_FILTER));
 					state.includeLights = caustic;
 
-					pRay.tmin = MIN_RAYDIST;
+					pRay.tmin = scene->raydist_min_bias;
 					pRay.tmax = -1.0;
 					pRay.from = hit->P;
 

--- a/src/integrators/photonintegr.cc
+++ b/src/integrators/photonintegr.cc
@@ -236,7 +236,7 @@ bool photonIntegrator_t::preprocess()
 		}
 
 		pcol = tmplights[lightNum]->emitPhoton(s1, s2, s3, s4, ray, lightPdf);
-		ray.tmin = MIN_RAYDIST;
+		ray.tmin = scene->raydist_min_bias;
 		ray.tmax = -1.0;
 		pcol *= fNumLights*lightPdf/lightNumPdf; //remember that lightPdf is the inverse of th pdf, hence *=...
 		
@@ -319,7 +319,7 @@ bool photonIntegrator_t::preprocess()
 
 			ray.from = sp.P;
 			ray.dir = wo;
-			ray.tmin = MIN_RAYDIST;
+			ray.tmin = scene->raydist_min_bias;
 			ray.tmax = -1.0;
 			++nBounces;
 		}
@@ -399,7 +399,7 @@ bool photonIntegrator_t::preprocess()
 			}
 
 			pcol = tmplights[lightNum]->emitPhoton(s1, s2, s3, s4, ray, lightPdf);
-			ray.tmin = MIN_RAYDIST;
+			ray.tmin = scene->raydist_min_bias;
 			ray.tmax = -1.0;
 			pcol *= fNumLights*lightPdf/lightNumPdf; //remember that lightPdf is the inverse of th pdf, hence *=...
 			if(pcol.isBlack())
@@ -478,7 +478,7 @@ bool photonIntegrator_t::preprocess()
 				
 				ray.from = sp.P;
 				ray.dir = wo;
-				ray.tmin = MIN_RAYDIST;
+				ray.tmin = scene->raydist_min_bias;
 				ray.tmax = -1.0;
 				++nBounces;
 			}
@@ -662,7 +662,7 @@ color_t photonIntegrator_t::finalGathering(renderState_t &state, const surfacePo
 		scol *= W;
 		if(scol.isBlack()) continue;
 
-		pRay.tmin = MIN_RAYDIST;
+		pRay.tmin = scene->raydist_min_bias;
 		pRay.tmax = -1.0;
 		pRay.from = hit.P;
 		throughput = scol;
@@ -729,7 +729,7 @@ color_t photonIntegrator_t::finalGathering(renderState_t &state, const surfacePo
 
 			scol *= W;
 
-			pRay.tmin = MIN_RAYDIST;
+			pRay.tmin = scene->raydist_min_bias;
 			pRay.tmax = -1.0;
 			pRay.from = hit.P;
 			throughput *= scol;

--- a/src/integrators/sppm.cc
+++ b/src/integrators/sppm.cc
@@ -322,7 +322,7 @@ void SPPM::prePass(int samples, int offset, bool adaptive)
 		if(lightNum >= numDLights){ Y_ERROR << integratorName << ": lightPDF sample error! "<<sL<<"/"<<lightNum<<"... stopping now.\n"; delete lightPowerD; return; }
 
 		pcol = tmplights[lightNum]->emitPhoton(s1, s2, s3, s4, ray, lightPdf);
-		ray.tmin = MIN_RAYDIST;
+		ray.tmin = scene->raydist_min_bias;
 		ray.tmax = -1.0;
 		pcol *= fNumLights*lightPdf/lightNumPdf; //remember that lightPdf is the inverse of th pdf, hence *=...
 
@@ -409,7 +409,7 @@ void SPPM::prePass(int samples, int offset, bool adaptive)
 
 			ray.from = sp.P;
 			ray.dir = wo;
-			ray.tmin = MIN_RAYDIST;
+			ray.tmin = scene->raydist_min_bias;
 			ray.tmax = -1.0;
 			++nBounces;
 
@@ -572,7 +572,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 					//temp.z = scale VDOT sp.N;
 
 					//double inv_radi = 1 / sqrt(radius2);
-					//temp.x  *= inv_radi; temp.y *= inv_radi; temp.z *=  1. / (2.f * MIN_RAYDIST);
+					//temp.x  *= inv_radi; temp.y *= inv_radi; temp.z *=  1. / (2.f * scene->raydist_min_bias);
 					//if(temp.lengthSqr() > 1.)continue;
 
 					gInfo.photonCount++;
@@ -660,7 +660,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 						state.chromatic = false;
 						color_t wl_col;
 						wl2rgb(state.wavelength, wl_col);
-						refRay = diffRay_t(sp.P, wi, MIN_RAYDIST);
+						refRay = diffRay_t(sp.P, wi, scene->raydist_min_bias);
 						t_cing = traceGatherRay(state, refRay, hp);
 						t_cing.photonFlux *= mcol * wl_col * W;
 						t_cing.constantRandiance *= mcol * wl_col * W;
@@ -726,7 +726,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 
 					if(s.sampledFlags & BSDF_GLOSSY)
 					{
-						refRay = diffRay_t(sp.P, wi, MIN_RAYDIST);
+						refRay = diffRay_t(sp.P, wi, scene->raydist_min_bias);
 						if(s.sampledFlags & BSDF_REFLECT) spDiff.reflectedRay(ray, refRay);
 						else if(s.sampledFlags & BSDF_TRANSMIT) spDiff.refractedRay(ray, refRay, material->getMatIOR());
 
@@ -768,7 +768,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 
 				if(reflect)
 				{
-					diffRay_t refRay(sp.P, dir[0], MIN_RAYDIST);
+					diffRay_t refRay(sp.P, dir[0], scene->raydist_min_bias);
 					spDiff.reflectedRay(ray, refRay); // compute the ray differentaitl
 					GatherInfo refg = traceGatherRay(state, refRay, hp);
 					if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
@@ -785,7 +785,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 				}
 				if(refract)
 				{
-					diffRay_t refRay(sp.P, dir[1], MIN_RAYDIST);
+					diffRay_t refRay(sp.P, dir[1], scene->raydist_min_bias);
 					spDiff.refractedRay(ray, refRay, material->getMatIOR());
 					GatherInfo refg = traceGatherRay(state, refRay, hp);
 					if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))

--- a/src/yafraycore/environment.cc
+++ b/src/yafraycore/environment.cc
@@ -634,6 +634,8 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	bool z_chan = false;
 	bool norm_z_chan = true;
 	bool drawParams = false;
+    bool gs_custom_shadow_bias_enabled=false;
+    float gs_custom_shadow_bias_value=0.0005;
 	const std::string *custString = 0;
 	std::stringstream aaSettings;
 
@@ -695,6 +697,8 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	params.getParam("normalize_z_channel", norm_z_chan); // normalize values of z-buffer in range [0,1]
 	params.getParam("drawParams", drawParams);
 	params.getParam("customString", custString);
+    params.getParam("gs_custom_shadow_bias_enabled", gs_custom_shadow_bias_enabled);
+    params.getParam("gs_custom_shadow_bias_value", gs_custom_shadow_bias_value);
 
 	imageFilm_t *film = createImageFilm(params, output);
 
@@ -722,6 +726,17 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	scene.setAntialiasing(AA_samples, AA_passes, AA_inc_samples, AA_threshold);
 	scene.setNumThreads(nthreads);
 	if(backg) scene.setBackground(backg);
+    if(gs_custom_shadow_bias_enabled)
+    {
+        scene.shadow_bias=gs_custom_shadow_bias_value;
+        scene.raydist_min_bias=gs_custom_shadow_bias_value/10.f;
+    }
+    else
+    {
+        scene.shadow_bias=0.0005;
+        scene.raydist_min_bias=0.00005;
+    }
+
 
 	return true;
 }

--- a/src/yafraycore/mcintegrator.cc
+++ b/src/yafraycore/mcintegrator.cc
@@ -78,7 +78,7 @@ inline color_t mcIntegrator_t::doLightEstimation(renderState_t &state, light_t *
 		if( light->illuminate(sp, lcol, lightRay) )
 		{
 			// ...shadowed...
-			lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is bad.
+			lightRay.tmin = scene->shadow_bias; // < better add some _smart_ self-bias value...this is bad.
 			shadowed = (trShad) ? scene->isShadowed(state, lightRay, sDepth, scol) : scene->isShadowed(state, lightRay);
 			if(!shadowed)
 			{
@@ -113,7 +113,7 @@ inline color_t mcIntegrator_t::doLightEstimation(renderState_t &state, light_t *
 			if( light->illumSample (sp, ls, lightRay) )
 			{
 				// ...shadowed...
-				lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is bad.
+				lightRay.tmin = scene->shadow_bias; // < better add some _smart_ self-bias value...this is bad.
 				shadowed = (trShad) ? scene->isShadowed(state, lightRay, sDepth, scol) : scene->isShadowed(state, lightRay);
 
 				if(!shadowed && ls.pdf > 1e-6f)
@@ -154,7 +154,7 @@ inline color_t mcIntegrator_t::doLightEstimation(renderState_t &state, light_t *
 			for(int i=0; i<n; ++i)
 			{
 				ray_t bRay;
-				bRay.tmin = MIN_RAYDIST; bRay.from = sp.P;
+				bRay.tmin = scene->raydist_min_bias; bRay.from = sp.P;
 
 				float s1 = hal2.getNext();
 				float s2 = hal3.getNext();
@@ -259,7 +259,7 @@ bool mcIntegrator_t::createCausticMap()
 			}
 
 			color_t pcol = causLights[lightNum]->emitPhoton(s1, s2, s3, s4, ray, lightPdf);
-			ray.tmin = MIN_RAYDIST;
+			ray.tmin = scene->raydist_min_bias;
 			ray.tmax = -1.0;
 			pcol *= fNumLights * lightPdf / lightNumPdf; //remember that lightPdf is the inverse of th pdf, hence *=...
 			if(pcol.isBlack())
@@ -338,7 +338,7 @@ bool mcIntegrator_t::createCausticMap()
 				}
 				ray.from = hit->P;
 				ray.dir = wo;
-				ray.tmin = MIN_RAYDIST;
+				ray.tmin = scene->raydist_min_bias;
 				ray.tmax = -1.0;
 				++nBounces;
 			}
@@ -456,7 +456,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
 					state.chromatic = false;
 					color_t wl_col;
 					wl2rgb(state.wavelength, wl_col);
-					refRay = diffRay_t(sp.P, wi, MIN_RAYDIST);
+					refRay = diffRay_t(sp.P, wi, scene->raydist_min_bias);
 					dcol += (color_t)integrate(state, refRay) * mcol * wl_col * W;
 					state.chromatic = true;
 				}
@@ -518,7 +518,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
                         sample_t s(s1, s2, BSDF_GLOSSY | BSDF_REFLECT);
                         color_t mcol = material->sample(state, sp, wo, wi, s, W);
                         colorA_t integ = 0.f;
-                        refRay = diffRay_t(sp.P, wi, MIN_RAYDIST);
+                        refRay = diffRay_t(sp.P, wi, scene->raydist_min_bias);
                         if(s.sampledFlags & BSDF_REFLECT) spDiff.reflectedRay(ray, refRay);
                         else if(s.sampledFlags & BSDF_TRANSMIT) spDiff.refractedRay(ray, refRay, material->getMatIOR());
                         integ = (color_t)integrate(state, refRay);
@@ -541,7 +541,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
 
                         if(s.sampledFlags & BSDF_REFLECT)
                         {
-                            refRay = diffRay_t(sp.P, dir[0], MIN_RAYDIST);
+                            refRay = diffRay_t(sp.P, dir[0], scene->raydist_min_bias);
                             spDiff.reflectedRay(ray, refRay);
                             integ = integrate(state, refRay);
                             if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
@@ -553,7 +553,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
 
                         if(s.sampledFlags & BSDF_TRANSMIT)
                         {
-                            refRay = diffRay_t(sp.P, dir[1], MIN_RAYDIST);
+                            refRay = diffRay_t(sp.P, dir[1], scene->raydist_min_bias);
                             spDiff.refractedRay(ray, refRay, material->getMatIOR());
                             integ = integrate(state, refRay);
                             if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
@@ -586,7 +586,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
 			const volumeHandler_t *vol;
 			if(reflect)
 			{
-				diffRay_t refRay(sp.P, dir[0], MIN_RAYDIST);
+				diffRay_t refRay(sp.P, dir[0], scene->raydist_min_bias);
 				spDiff.reflectedRay(ray, refRay);
 				color_t integ = integrate(state, refRay);
 
@@ -599,7 +599,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
 			}
 			if(refract)
 			{
-				diffRay_t refRay(sp.P, dir[1], MIN_RAYDIST);
+				diffRay_t refRay(sp.P, dir[1], scene->raydist_min_bias);
 				spDiff.refractedRay(ray, refRay, material->getMatIOR());
 				colorA_t integ = integrate(state, refRay);
 
@@ -647,7 +647,7 @@ color_t mcIntegrator_t::sampleAmbientOcclusion(renderState_t &state, const surfa
 			s2 = addMod1(s2, state.dc2);
 		}
 
-		lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is still bad...
+		lightRay.tmin = scene->shadow_bias; // < better add some _smart_ self-bias value...this is still bad...
 		lightRay.tmax = aoDist;
 
 		float W = 0.f;


### PR DESCRIPTION
Due to several bug reports showing very ugly black dots caused by wrong selfshadowing, I'm exposing the Shadow Bias to the user. By default it will continue being 0.0005 and the MIN_RAYDIST 0.00005 (10 times smaller), but if needed the user can enable a custom shadow bias and then the RAY_MINDIST will be calculated as SHADOW_BIAS / 10

This is NOT ideal, we should change this in the near future to include an automatic bias calculation, but for the time being and to keep compatibility with existing scenes, I will just expose the setting in case it's needed.

 Changes to be committed:
	modified:   include/core_api/scene.h
	modified:   src/integrators/SingleScatterIntegrator.cc
	modified:   src/integrators/bidirpath.cc
	modified:   src/integrators/pathtracer.cc
	modified:   src/integrators/photonintegr.cc
	modified:   src/integrators/sppm.cc
	modified:   src/yafraycore/environment.cc
	modified:   src/yafraycore/mcintegrator.cc