### PR TITLE
Fix for problem of Black areas with NaN results

### DIFF
--- a/include/core_api/vector3d.h
+++ b/include/core_api/vector3d.h
@@ -262,7 +262,11 @@ inline vector3d_t& vector3d_t::normalize()
 inline float vector3d_t::sinFromVectors(const vector3d_t& v)
 {
     float div = ( length() * v.length() ) * 0.99999f + 0.00001f;
-    return asin( ( (*this ^ v ).length() / div) * 0.99999f );
+    float asin_argument =  ( (*this ^ v ).length() / div) * 0.99999f;
+    //Fix to avoid black "nan" areas when this argument goes slightly outside the valid domain [-1.0 .. +1.0]. Why that values goes outside the range in the first place, maybe floating point rounding errors?
+    if(asin_argument > 1.f) asin_argument = 1.f;
+    else if(asin_argument < -1.f) asin_argument = -1.f;
+    return asin(asin_argument);
 }
 
 inline normal_t& normal_t::normalize()


### PR DESCRIPTION
I could make a scene with large black areas with NaN pixels. See:  http://yafaray.org/node/623

I found that in vector3d.h there is an asin() function where the argument sometimes was very slightly bigger than 1.0, causing the nan result from the asin() function.

I've fixed it adding a domain check to force the asin argument to always be in the correct domain range [-1.0 .. +1.0]

 Changes to be committed:
	modified:   include/core_api/vector3d.h