### PR TITLE
Possible speed up change in the NaN fix?

### DIFF
--- a/include/core_api/vector3d.h
+++ b/include/core_api/vector3d.h
@@ -263,9 +263,8 @@ inline float vector3d_t::sinFromVectors(const vector3d_t& v)
 {
     float div = ( length() * v.length() ) * 0.99999f + 0.00001f;
     float asin_argument =  ( (*this ^ v ).length() / div) * 0.99999f;
-    //Fix to avoid black "nan" areas when this argument goes slightly outside the valid domain [-1.0 .. +1.0]. Why that values goes outside the range in the first place, maybe floating point rounding errors?
+    //Fix to avoid black "nan" areas when this argument goes slightly over +1.0. Why that happens in the first place, maybe floating point rounding errors?
     if(asin_argument > 1.f) asin_argument = 1.f;
-    else if(asin_argument < -1.f) asin_argument = -1.f;
     return asin(asin_argument);
 }
 


### PR DESCRIPTION
Thinking this again, perhaps we can make a small speed up change. Because we are using lengths these are (in theory) only positive values so we don't need to check that the asin argument is less than -1.0?  In my tests, checking only for > 1.0 is enough to remove the black NaN areas.

Not sure how much speed would we gain from removing the check for -1.0?

If you think this is a good idea, please merge. If you think the speed change will be very small and you want to keep the fix as it is (checking both +1.0 and -1.0) then please close this pull request.