### PR TITLE
Automatic Shadow Bias and Min Ray Dist calculation

### DIFF
--- a/include/core_api/scene.h
+++ b/include/core_api/scene.h
@@ -207,6 +207,10 @@ class YAFRAYCORE_EXPORT scene_t
 		std::vector<light_t *> lights;
 		volumeIntegrator_t *volIntegrator;
 
+        PFLOAT shadowBias;  //shadow bias to apply to shadows to avoid self-shadow artifacts
+        PFLOAT rayMinDist;  //ray minimum distance
+
+
 	protected:
 
 		sceneGeometryState_t state;

--- a/include/yafraycore/kdtree.h
+++ b/include/yafraycore/kdtree.h
@@ -131,8 +131,8 @@ public:
 			float cost_ratio=0.35, float emptyBonus=0.33);
 	bool Intersect(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFLOAT &Z, intersectData_t &data) const;
 //	bool IntersectDBG(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFLOAT &Z) const;
-	bool IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr) const;
-	bool IntersectTS(renderState_t &state, const ray_t &ray, int maxDepth, PFLOAT dist, triangle_t **tr, color_t &filt) const;
+	bool IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFLOAT shadow_bias) const;
+	bool IntersectTS(renderState_t &state, const ray_t &ray, int maxDepth, PFLOAT dist, triangle_t **tr, color_t &filt, PFLOAT shadow_bias) const;
 //	bool IntersectO(const point3d_t &from, const vector3d_t &ray, PFLOAT dist, triangle_t **tr, PFLOAT &Z) const;
 	bound_t getBound(){ return treeBound; }
 	~triKdTree_t();

--- a/include/yafraycore/ray_kdtree.h
+++ b/include/yafraycore/ray_kdtree.h
@@ -84,8 +84,8 @@ public:
 			float cost_ratio=0.35, float emptyBonus=0.33);
 	bool Intersect(const ray_t &ray, PFLOAT dist, T **tr, PFLOAT &Z, intersectData_t &data) const;
 //	bool IntersectDBG(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFLOAT &Z) const;
-	bool IntersectS(const ray_t &ray, PFLOAT dist, T **tr) const;
-	bool IntersectTS(renderState_t &state, const ray_t &ray, int maxDepth, PFLOAT dist, T **tr, color_t &filt) const;
+	bool IntersectS(const ray_t &ray, PFLOAT dist, T **tr, PFLOAT shadow_bias) const;
+	bool IntersectTS(renderState_t &state, const ray_t &ray, int maxDepth, PFLOAT dist, T **tr, color_t &filt, PFLOAT shadow_bias) const;
 //	bool IntersectO(const point3d_t &from, const vector3d_t &ray, PFLOAT dist, T **tr, PFLOAT &Z) const;
 	bound_t getBound(){ return treeBound; }
 	~kdTree_t();

--- a/src/integrators/SingleScatterIntegrator.cc
+++ b/src/integrators/SingleScatterIntegrator.cc
@@ -95,7 +95,7 @@ public:
 								if( (*l)->diracLight() )
 								{
 									bool ill = (*l)->illuminate(sp, lcol, lightRay);
-									lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is bad.
+									lightRay.tmin = scene->shadowBias;
 									if (lightRay.tmax < 0.f) lightRay.tmax = 1e10; // infinitely distant light
 
 									// transmittance from the point p in the volume to the light (i.e. how much light reaches p)
@@ -124,7 +124,7 @@ public:
 										ls.s2 = 0.5f; //(*state.prng)();
 
 										(*l)->illumSample(sp, ls, lightRay);
-										lightRay.tmin = YAF_SHADOW_BIAS;
+										lightRay.tmin = scene->shadowBias;
 										if (lightRay.tmax < 0.f) lightRay.tmax = 1e10; // infinitely distant light
 
 										// transmittance from the point p in the volume to the light (i.e. how much light reaches p)
@@ -168,7 +168,6 @@ public:
 				if( (*l)->illuminate(sp, lcol, lightRay) )
 				{
 					// ...shadowed...
-					lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is bad.
 					if (lightRay.tmax < 0.f) lightRay.tmax = 1e10; // infinitely distant light
 					bool shadowed = scene->isShadowed(state, lightRay);
 					if (!shadowed)
@@ -225,7 +224,6 @@ public:
 					if((*l)->illumSample(sp, ls, lightRay))
 					{
 						// ...shadowed...
-						lightRay.tmin = YAF_SHADOW_BIAS; // < better add some _smart_ self-bias value...this is bad.
 						if (lightRay.tmax < 0.f) lightRay.tmax = 1e10; // infinitely distant light
 						bool shadowed = scene->isShadowed(state, lightRay);
 						if(!shadowed) {

--- a/src/integrators/bidirpath.cc
+++ b/src/integrators/bidirpath.cc
@@ -295,7 +295,7 @@ colorA_t biDirIntegrator_t::integrate(renderState_t &state, diffRay_t &ray) cons
 
 		// sample light (todo!)
 		ray_t lray;
-		lray.tmin = MIN_RAYDIST;
+		lray.tmin = scene->rayMinDist;
 		lray.tmax = -1.f;
 		float lightNumPdf;
 		int lightNum = lightPowerD->DSample(prng(), &lightNumPdf);
@@ -479,7 +479,7 @@ int biDirIntegrator_t::createPath(renderState_t &state, ray_t &start, std::vecto
 		v.flags = s.sampledFlags;
 		v.wo = ray.dir;
 		ray.from = v.sp.P;
-		ray.tmin = MIN_RAYDIST;
+		ray.tmin = scene->rayMinDist;
 		ray.tmax = -1.f;
 	}
 	++dbg;

--- a/src/integrators/pathtracer.cc
+++ b/src/integrators/pathtracer.cc
@@ -193,7 +193,7 @@ colorA_t pathIntegrator_t::integrate(renderState_t &state, diffRay_t &ray/*, sam
 				throughput = scol;
 				state.includeLights = false;
 
-				pRay.tmin = MIN_RAYDIST;
+				pRay.tmin = scene->rayMinDist;
 				pRay.tmax = -1.0;
 				pRay.from = sp.P;
 				
@@ -234,7 +234,7 @@ colorA_t pathIntegrator_t::integrate(renderState_t &state, diffRay_t &ray/*, sam
 					caustic = traceCaustics && (s.sampledFlags & (BSDF_SPECULAR | BSDF_GLOSSY | BSDF_FILTER));
 					state.includeLights = caustic;
 
-					pRay.tmin = MIN_RAYDIST;
+					pRay.tmin = scene->rayMinDist;
 					pRay.tmax = -1.0;
 					pRay.from = hit->P;
 

--- a/src/integrators/photonintegr.cc
+++ b/src/integrators/photonintegr.cc
@@ -236,7 +236,7 @@ bool photonIntegrator_t::preprocess()
 		}
 
 		pcol = tmplights[lightNum]->emitPhoton(s1, s2, s3, s4, ray, lightPdf);
-		ray.tmin = MIN_RAYDIST;
+		ray.tmin = scene->rayMinDist;
 		ray.tmax = -1.0;
 		pcol *= fNumLights*lightPdf/lightNumPdf; //remember that lightPdf is the inverse of th pdf, hence *=...
 		
@@ -319,7 +319,7 @@ bool photonIntegrator_t::preprocess()
 
 			ray.from = sp.P;
 			ray.dir = wo;
-			ray.tmin = MIN_RAYDIST;
+			ray.tmin = scene->rayMinDist;
 			ray.tmax = -1.0;
 			++nBounces;
 		}
@@ -399,7 +399,7 @@ bool photonIntegrator_t::preprocess()
 			}
 
 			pcol = tmplights[lightNum]->emitPhoton(s1, s2, s3, s4, ray, lightPdf);
-			ray.tmin = MIN_RAYDIST;
+			ray.tmin = scene->rayMinDist;
 			ray.tmax = -1.0;
 			pcol *= fNumLights*lightPdf/lightNumPdf; //remember that lightPdf is the inverse of th pdf, hence *=...
 			if(pcol.isBlack())
@@ -478,7 +478,7 @@ bool photonIntegrator_t::preprocess()
 				
 				ray.from = sp.P;
 				ray.dir = wo;
-				ray.tmin = MIN_RAYDIST;
+				ray.tmin = scene->rayMinDist;
 				ray.tmax = -1.0;
 				++nBounces;
 			}
@@ -662,7 +662,7 @@ color_t photonIntegrator_t::finalGathering(renderState_t &state, const surfacePo
 		scol *= W;
 		if(scol.isBlack()) continue;
 
-		pRay.tmin = MIN_RAYDIST;
+		pRay.tmin = scene->rayMinDist;
 		pRay.tmax = -1.0;
 		pRay.from = hit.P;
 		throughput = scol;
@@ -729,7 +729,7 @@ color_t photonIntegrator_t::finalGathering(renderState_t &state, const surfacePo
 
 			scol *= W;
 
-			pRay.tmin = MIN_RAYDIST;
+			pRay.tmin = scene->rayMinDist;
 			pRay.tmax = -1.0;
 			pRay.from = hit.P;
 			throughput *= scol;

--- a/src/integrators/sppm.cc
+++ b/src/integrators/sppm.cc
@@ -322,7 +322,7 @@ void SPPM::prePass(int samples, int offset, bool adaptive)
 		if(lightNum >= numDLights){ Y_ERROR << integratorName << ": lightPDF sample error! "<<sL<<"/"<<lightNum<<"... stopping now.\n"; delete lightPowerD; return; }
 
 		pcol = tmplights[lightNum]->emitPhoton(s1, s2, s3, s4, ray, lightPdf);
-		ray.tmin = MIN_RAYDIST;
+		ray.tmin = scene->rayMinDist;
 		ray.tmax = -1.0;
 		pcol *= fNumLights*lightPdf/lightNumPdf; //remember that lightPdf is the inverse of th pdf, hence *=...
 
@@ -409,7 +409,7 @@ void SPPM::prePass(int samples, int offset, bool adaptive)
 
 			ray.from = sp.P;
 			ray.dir = wo;
-			ray.tmin = MIN_RAYDIST;
+			ray.tmin = scene->rayMinDist;
 			ray.tmax = -1.0;
 			++nBounces;
 
@@ -572,7 +572,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 					//temp.z = scale VDOT sp.N;
 
 					//double inv_radi = 1 / sqrt(radius2);
-					//temp.x  *= inv_radi; temp.y *= inv_radi; temp.z *=  1. / (2.f * MIN_RAYDIST);
+					//temp.x  *= inv_radi; temp.y *= inv_radi; temp.z *=  1. / (2.f * scene->rayMinDist);
 					//if(temp.lengthSqr() > 1.)continue;
 
 					gInfo.photonCount++;
@@ -660,7 +660,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 						state.chromatic = false;
 						color_t wl_col;
 						wl2rgb(state.wavelength, wl_col);
-						refRay = diffRay_t(sp.P, wi, MIN_RAYDIST);
+						refRay = diffRay_t(sp.P, wi, scene->rayMinDist);
 						t_cing = traceGatherRay(state, refRay, hp);
 						t_cing.photonFlux *= mcol * wl_col * W;
 						t_cing.constantRandiance *= mcol * wl_col * W;
@@ -726,7 +726,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 
 					if(s.sampledFlags & BSDF_GLOSSY)
 					{
-						refRay = diffRay_t(sp.P, wi, MIN_RAYDIST);
+						refRay = diffRay_t(sp.P, wi, scene->rayMinDist);
 						if(s.sampledFlags & BSDF_REFLECT) spDiff.reflectedRay(ray, refRay);
 						else if(s.sampledFlags & BSDF_TRANSMIT) spDiff.refractedRay(ray, refRay, material->getMatIOR());
 
@@ -768,7 +768,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 
 				if(reflect)
 				{
-					diffRay_t refRay(sp.P, dir[0], MIN_RAYDIST);
+					diffRay_t refRay(sp.P, dir[0], scene->rayMinDist);
 					spDiff.reflectedRay(ray, refRay); // compute the ray differentaitl
 					GatherInfo refg = traceGatherRay(state, refRay, hp);
 					if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
@@ -785,7 +785,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 				}
 				if(refract)
 				{
-					diffRay_t refRay(sp.P, dir[1], MIN_RAYDIST);
+					diffRay_t refRay(sp.P, dir[1], scene->rayMinDist);
 					spDiff.refractedRay(ray, refRay, material->getMatIOR());
 					GatherInfo refg = traceGatherRay(state, refRay, hp);
 					if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))

--- a/src/yafraycore/kdtree.cc
+++ b/src/yafraycore/kdtree.cc
@@ -799,7 +799,7 @@ bool triKdTree_t::Intersect(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFLO
 }
 
 
-bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr) const
+bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFLOAT shadow_bias) const
 {
 	PFLOAT a, b, t; // entry/exit/splitting plane signed distance
 	PFLOAT t_hit;
@@ -895,7 +895,7 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr) con
 			triangle_t *mp = currNode->onePrimitive;
 			if (mp->intersect(ray, &t_hit, bary))
 			{
-				if(t_hit < dist && t_hit >= 0.f ) // '>=' ?
+				if(t_hit < dist && t_hit >= shadow_bias ) // '>=' ?
 				{
 					*tr = mp;
 					return true;
@@ -910,7 +910,7 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr) con
 				triangle_t *mp = prims[i];
 				if (mp->intersect(ray, &t_hit, bary))
 				{
-					if(t_hit < dist && t_hit >= 0.f )
+					if(t_hit < dist && t_hit >= shadow_bias )
 					{
 						*tr = mp;
 						return true;
@@ -932,7 +932,7 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr) con
 	allow for transparent shadows.
 =============================================================*/
 
-bool triKdTree_t::IntersectTS(renderState_t &state, const ray_t &ray, int maxDepth, PFLOAT dist, triangle_t **tr, color_t &filt) const
+bool triKdTree_t::IntersectTS(renderState_t &state, const ray_t &ray, int maxDepth, PFLOAT dist, triangle_t **tr, color_t &filt, PFLOAT shadow_bias) const
 {
 	PFLOAT a, b, t; // entry/exit/splitting plane signed distance
 	PFLOAT t_hit;
@@ -1034,7 +1034,7 @@ bool triKdTree_t::IntersectTS(renderState_t &state, const ray_t &ray, int maxDep
 			triangle_t *mp = currNode->onePrimitive;
 			if (mp->intersect(ray, &t_hit, bary))
 			{
-				if(t_hit < dist && t_hit >= ray.tmin ) // '>=' ?
+				if(t_hit < dist && t_hit >= shadow_bias ) // '>=' ?
 				{
 					const material_t *mat = mp->getMaterial();
 					
@@ -1060,7 +1060,7 @@ bool triKdTree_t::IntersectTS(renderState_t &state, const ray_t &ray, int maxDep
 				triangle_t *mp = prims[i];
 				if (mp->intersect(ray, &t_hit, bary))
 				{
-					if(t_hit < dist && t_hit >= ray.tmin)
+					if(t_hit < dist && t_hit >= shadow_bias)
 					{
 						const material_t *mat = mp->getMaterial();
 

--- a/src/yafraycore/ray_kdtree.cc
+++ b/src/yafraycore/ray_kdtree.cc
@@ -830,7 +830,7 @@ bool kdTree_t<T>::Intersect(const ray_t &ray, PFLOAT dist, T **tr, PFLOAT &Z, in
 }
 
 template<class T>
-bool kdTree_t<T>::IntersectS(const ray_t &ray, PFLOAT dist, T **tr) const
+bool kdTree_t<T>::IntersectS(const ray_t &ray, PFLOAT dist, T **tr, PFLOAT shadow_bias) const
 {
 	PFLOAT a, b, t; // entry/exit/splitting plane signed distance
 	PFLOAT t_hit;
@@ -924,7 +924,7 @@ bool kdTree_t<T>::IntersectS(const ray_t &ray, PFLOAT dist, T **tr) const
 			T *mp = currNode->onePrimitive;
 			if (mp->intersect(ray, &t_hit, bary))
 			{
-				if(t_hit < dist && t_hit > ray.tmin )
+				if(t_hit < dist && t_hit > shadow_bias )
 				{
 					*tr = mp;
 					return true;
@@ -939,7 +939,7 @@ bool kdTree_t<T>::IntersectS(const ray_t &ray, PFLOAT dist, T **tr) const
 				T *mp = prims[i];
 					if (mp->intersect(ray, &t_hit, bary))
 					{
-						if(t_hit < dist && t_hit > ray.tmin )
+						if(t_hit < dist && t_hit > shadow_bias )
 						{
 							*tr = mp;
 							return true;
@@ -962,7 +962,7 @@ bool kdTree_t<T>::IntersectS(const ray_t &ray, PFLOAT dist, T **tr) const
 =============================================================*/
 
 template<class T>
-bool kdTree_t<T>::IntersectTS(renderState_t &state, const ray_t &ray, int maxDepth, PFLOAT dist, T **tr, color_t &filt) const
+bool kdTree_t<T>::IntersectTS(renderState_t &state, const ray_t &ray, int maxDepth, PFLOAT dist, T **tr, color_t &filt, PFLOAT shadow_bias) const
 {
 	PFLOAT a, b, t; // entry/exit/splitting plane signed distance
 	PFLOAT t_hit;
@@ -1062,7 +1062,7 @@ bool kdTree_t<T>::IntersectTS(renderState_t &state, const ray_t &ray, int maxDep
 			T *mp = currNode->onePrimitive;
 			if (mp->intersect(ray, &t_hit, bary))
 			{
-				if(t_hit < dist && t_hit >= ray.tmin )
+				if(t_hit < dist && t_hit >= shadow_bias )
 				{
 					const material_t *mat = mp->getMaterial();
 					if(!mat->isTransparent() ) return true;
@@ -1085,7 +1085,7 @@ bool kdTree_t<T>::IntersectTS(renderState_t &state, const ray_t &ray, int maxDep
 				T *mp = prims[i];
 				if (mp->intersect(ray, &t_hit, bary))
 				{
-					if(t_hit < dist && t_hit >= ray.tmin )
+					if(t_hit < dist && t_hit >= shadow_bias )
 					{
 						const material_t *mat = mp->getMaterial();
 						if(!mat->isTransparent() ) return true;


### PR DESCRIPTION
This is a very experimental change. Until now the Shadow Bias and Min Ray Dists were constant and independent of the scene size. Due to numeric precission and fast calculations limitations it tended to cause black artifacts in scenes with long triangles and/or big objects.

With this change, the Shadow Bias and Min Ray Dist calculations will be automatically calculated and showed in the YafaRay console log as in the following example:

INFO: Scene: total scene dimensions: X=994.484, Y=994.484, Z=1001.61, volume=9.90586e+08, calculated Shadow Bias=0.500803, calculated Ray Min Dist=0.250401

This change needs to be extensively tested to ensure it does not introduce new issues as it affects the fundamental calculations for shadows, photon mapping and other integrators. In any case, I hope it helps.

 Changes to be committed:
	modified:   include/core_api/scene.h
	modified:   include/yafraycore/kdtree.h
	modified:   include/yafraycore/ray_kdtree.h
	modified:   src/integrators/SingleScatterIntegrator.cc
	modified:   src/integrators/bidirpath.cc
	modified:   src/integrators/pathtracer.cc
	modified:   src/integrators/photonintegr.cc
	modified:   src/integrators/sppm.cc
	modified:   src/yafraycore/kdtree.cc
	modified:   src/yafraycore/mcintegrator.cc
	modified:   src/yafraycore/ray_kdtree.cc
	modified:   src/yafraycore/scene.cc