### PR TITLE
New parameter - cast shadows

### DIFF
--- a/include/core_api/material.h
+++ b/include/core_api/material.h
@@ -105,6 +105,7 @@ class YAFRAYCORE_EXPORT material_t
 			used to trace transparent shadows. Note that in this case, initBSDF was NOT called before!
 		*/
 		virtual bool isTransparent() const { return false; }
+		virtual bool castShadows() const { return true; }
 
 		/*!	used for computing transparent shadows.	Default implementation returns black (i.e. solid shadow).
 			This is only used for shadow calculations and may only be called when isTransparent returned true.	*/

--- a/include/materials/blendmat.h
+++ b/include/materials/blendmat.h
@@ -18,7 +18,7 @@ __BEGIN_YAFRAY
 class blendMat_t: public nodeMaterial_t
 {
 	public:
-		blendMat_t(const material_t *m1, const material_t *m2, float blendv);
+		blendMat_t(const material_t *m1, const material_t *m2, float blendv, bool bCastShadows=true);
 		virtual ~blendMat_t();
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const;
@@ -26,6 +26,7 @@ class blendMat_t: public nodeMaterial_t
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual float getMatIOR ()const;
 		virtual bool isTransparent() const;
+		virtual bool castShadows() const { return mCastShadows; }
 		virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual color_t emit(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo,
@@ -44,6 +45,7 @@ class blendMat_t: public nodeMaterial_t
 		bool recalcBlend;
 		float blendedIOR;
 		mutable BSDF_t mat1Flags, mat2Flags;
+		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
 	private:
 		void getBlendVal(const renderState_t &state, const surfacePoint_t &sp, float &val, float &ival) const;
 };

--- a/include/materials/maskmat.h
+++ b/include/materials/maskmat.h
@@ -12,12 +12,13 @@ class renderEnvironment_t;
 class maskMat_t: public nodeMaterial_t
 {
 	public:
-		maskMat_t(const material_t *m1, const material_t *m2, CFLOAT thresh);
+		maskMat_t(const material_t *m1, const material_t *m2, CFLOAT thresh, bool bCastShadows=true);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual bool isTransparent() const;
+		virtual bool castShadows() const { return mCastShadows; }
 		virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo,
 								 bool &reflect, bool &refract, vector3d_t *const dir, color_t *const col)const;
@@ -30,6 +31,7 @@ class maskMat_t: public nodeMaterial_t
 		const material_t *mat2;
 		shaderNode_t* mask;
 		CFLOAT threshold;
+		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
 		//const texture_t *mask;
 };
 

--- a/include/materials/roughglass.h
+++ b/include/materials/roughglass.h
@@ -9,13 +9,14 @@ __BEGIN_YAFRAY
 class roughGlassMat_t: public nodeMaterial_t
 {
 	public:
-		roughGlassMat_t(float IOR, color_t filtC, const color_t &srcol, bool fakeS, float alpha, float disp_pow);
+		roughGlassMat_t(float IOR, color_t filtC, const color_t &srcol, bool fakeS, float alpha, float disp_pow, bool bCastShadows=true);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes) const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W) const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t *const dir, color_t &tcol, sample_t &s, float *const W)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs) const { return 0.f; }
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs) const { return 0.f; }
 		virtual bool isTransparent() const { return fakeShadow; }
+		virtual bool castShadows() const { return mCastShadows; }
 		virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo) const;
 		virtual float getAlpha(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo) const;
 		virtual float getMatIOR() const;
@@ -31,6 +32,7 @@ class roughGlassMat_t: public nodeMaterial_t
 		float a;
 		bool absorb, disperse, fakeShadow;
 		float CauchyA, CauchyB;
+		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
 };
 
 __END_YAFRAY

--- a/include/materials/shinydiff.h
+++ b/include/materials/shinydiff.h
@@ -24,13 +24,14 @@ __BEGIN_YAFRAY
 class shinyDiffuseMat_t: public nodeMaterial_t
 {
     public:
-        shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength=0.0, float translucencyStrength=0.0, float mirrorStrength=0.0, float emitStrength=0.0, float transmitFilterStrength=1.0);
+        shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength=0.0, float translucencyStrength=0.0, float mirrorStrength=0.0, float emitStrength=0.0, float transmitFilterStrength=1.0, bool bCastShadows=true);
         virtual ~shinyDiffuseMat_t();
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
         virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const;
         virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
         virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
         virtual bool isTransparent() const { return mIsTransparent; }
+        virtual bool castShadows() const { return mCastShadows; }
         virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
         virtual color_t emit(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const; // { return emitCol; }
         virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, bool &reflect, bool &refract, vector3d_t *const dir, color_t *const col)const;
@@ -81,8 +82,10 @@ class shinyDiffuseMat_t: public nodeMaterial_t
         bool mUseOrenNayar;                 //!< Use Oren Nayar reflectance (default Lambertian)
         float mOrenNayar_A;                 //!< Oren Nayar A coefficient
         float mOrenNayar_B;                 //!< Oren Nayar B coefficient
-
+        
         int nBSDF;
+        bool mCastShadows;                  //!< enables/disables casting shadows. It should always be enabled except in specific cases.
+
         BSDF_t cFlags[4];                   //!< list the BSDF components that are present
         int cIndex[4];                      //!< list the index of the BSDF components (0=specular reflection, 1=specular transparency, 2=translucency, 3=diffuse reflection)
 };

--- a/src/materials/blend.cc
+++ b/src/materials/blend.cc
@@ -30,8 +30,8 @@ __BEGIN_YAFRAY
 
 #define addPdf(p1, p2) (p1*ival + p2*val)
 
-blendMat_t::blendMat_t(const material_t *m1, const material_t *m2, float bval):
-	mat1(m1), mat2(m2), blendS(0)
+blendMat_t::blendMat_t(const material_t *m1, const material_t *m2, float bval, bool bCastShadows):
+	mat1(m1), mat2(m2), blendS(0), mCastShadows(bCastShadows)
 {
 	bsdfFlags = mat1->getFlags() | mat2->getFlags();
 	mmem1 = mat1->getReqMem();
@@ -389,16 +389,18 @@ material_t* blendMat_t::factory(paraMap_t &params, std::list<paraMap_t> &eparams
 	const std::string *name = 0;
 	const material_t *m1=0, *m2=0;
 	double blend_val = 0.5;
+	bool bCastShadows=true;
 	
 	if(! params.getParam("material1", name) ) return 0;
 	m1 = env.getMaterial(*name);
 	if(! params.getParam("material2", name) ) return 0;
 	m2 = env.getMaterial(*name);
 	params.getParam("blend_value", blend_val);
+	params.getParam("cast_shadows",     bCastShadows);
 	
 	if(m1==0 || m2==0 ) return 0;
 	
-	blendMat_t *mat = new blendMat_t(m1, m2, blend_val);
+	blendMat_t *mat = new blendMat_t(m1, m2, blend_val, bCastShadows);
 	
 	std::vector<shaderNode_t *> roots;
 	if(mat->loadNodes(eparams, env))

--- a/src/materials/coatedglossy.cc
+++ b/src/materials/coatedglossy.cc
@@ -39,7 +39,7 @@ __BEGIN_YAFRAY
 class coatedGlossyMat_t: public nodeMaterial_t
 {
 	public:
-		coatedGlossyMat_t(const color_t &col, const color_t &dcol, const color_t &mirCol, float reflect, float diff, PFLOAT ior, float expo, bool as_diff);
+		coatedGlossyMat_t(const color_t &col, const color_t &dcol, const color_t &mirCol, float reflect, float diff, PFLOAT ior, float expo, bool as_diff, bool bCastShadows);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
@@ -47,6 +47,7 @@ class coatedGlossyMat_t: public nodeMaterial_t
 		virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo,
 								 bool &refl, bool &refr, vector3d_t *const dir, color_t *const col)const;
 		static material_t* factory(paraMap_t &, std::list< paraMap_t > &, renderEnvironment_t &);
+		virtual bool castShadows() const { return mCastShadows; }
 
 		struct MDat_t
 		{
@@ -75,11 +76,12 @@ class coatedGlossyMat_t: public nodeMaterial_t
 		int nBSDF;
 		bool orenNayar;
 		float orenA, orenB;
+		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
 };
 
-coatedGlossyMat_t::coatedGlossyMat_t(const color_t &col, const color_t &dcol, const color_t &mirCol, float reflect, float diff, PFLOAT ior, float expo, bool as_diff):
+coatedGlossyMat_t::coatedGlossyMat_t(const color_t &col, const color_t &dcol, const color_t &mirCol, float reflect, float diff, PFLOAT ior, float expo, bool as_diff, bool bCastShadows):
 	diffuseS(0), glossyS(0), glossyRefS(0), bumpS(0), gloss_color(col), diff_color(dcol), mirror_color(mirCol), IOR(ior), exponent(expo), reflectivity(reflect), mDiffuse(diff),
-	as_diffuse(as_diff), with_diffuse(false), anisotropic(false)
+	as_diffuse(as_diff), with_diffuse(false), anisotropic(false), mCastShadows(bCastShadows)
 {
 	cFlags[C_SPECULAR] = (BSDF_SPECULAR | BSDF_REFLECT);
 	cFlags[C_GLOSSY] = as_diffuse? (BSDF_DIFFUSE | BSDF_REFLECT) : (BSDF_GLOSSY | BSDF_REFLECT);
@@ -427,6 +429,7 @@ material_t* coatedGlossyMat_t::factory(paraMap_t &params, std::list< paraMap_t >
 	bool as_diff=true;
 	bool aniso=false;
 	const std::string *name=0;
+	bool bCastShadows = true;
 
 	params.getParam("color", col);
 	params.getParam("diffuse_color", dcol);
@@ -437,10 +440,11 @@ material_t* coatedGlossyMat_t::factory(paraMap_t &params, std::list< paraMap_t >
 	params.getParam("anisotropic", aniso);
 	params.getParam("IOR", ior);
 	params.getParam("mirror_color", mirCol);
+	params.getParam("cast_shadows",     bCastShadows);
 
 	if(ior == 1.f) ior = 1.0000001f;
 
-	coatedGlossyMat_t *mat = new coatedGlossyMat_t(col, dcol, mirCol, refl, diff, ior, exponent, as_diff);
+	coatedGlossyMat_t *mat = new coatedGlossyMat_t(col, dcol, mirCol, refl, diff, ior, exponent, as_diff, bCastShadows);
 	if(aniso)
 	{
 		double e_u=50.0, e_v=50.0;

--- a/src/materials/glass.cc
+++ b/src/materials/glass.cc
@@ -28,12 +28,13 @@ __BEGIN_YAFRAY
 class glassMat_t: public nodeMaterial_t
 {
 	public:
-		glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS);
+		glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS, bool bCastShadows);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const {return color_t(0.0);}
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const {return 0.f;}
 		virtual bool isTransparent() const { return fakeShadow; }
+		virtual bool castShadows() const { return mCastShadows; }
 		virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual CFLOAT getAlpha(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo,
@@ -50,11 +51,12 @@ class glassMat_t: public nodeMaterial_t
 		BSDF_t tmFlags;
 		PFLOAT dispersion_power;
 		PFLOAT CauchyA, CauchyB;
+		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
 };
 
-glassMat_t::glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS):
+glassMat_t::glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS, bool bCastShadows):
 		bumpS(0), mirColS(0), filterCol(filtC), specRefCol(srcol), absorb(false), disperse(false),
-		fakeShadow(fakeS), dispersion_power(disp_pow)
+		fakeShadow(fakeS), dispersion_power(disp_pow), mCastShadows(bCastShadows)
 {
 	ior=IOR;
 	bsdfFlags = BSDF_ALL_SPECULAR;
@@ -265,13 +267,16 @@ material_t* glassMat_t::factory(paraMap_t &params, std::list< paraMap_t > &param
 	color_t filtCol(1.f), absorp(1.f), srCol(1.f);
 	const std::string *name=0;
 	bool fake_shad = false;
+	bool bCastShadows = true;
+	
 	params.getParam("IOR", IOR);
 	params.getParam("filter_color", filtCol);
 	params.getParam("transmit_filter", filt);
 	params.getParam("mirror_color", srCol);
 	params.getParam("dispersion_power", disp_power);
 	params.getParam("fake_shadows", fake_shad);
-	glassMat_t *mat = new glassMat_t(IOR, filt*filtCol + color_t(1.f-filt), srCol, disp_power, fake_shad);
+	params.getParam("cast_shadows",     bCastShadows);
+	glassMat_t *mat = new glassMat_t(IOR, filt*filtCol + color_t(1.f-filt), srCol, disp_power, fake_shad, bCastShadows);
 	if( params.getParam("absorption", absorp) )
 	{
 		double dist=1.f;

--- a/src/materials/glossy.cc
+++ b/src/materials/glossy.cc
@@ -30,12 +30,13 @@ __BEGIN_YAFRAY
 class glossyMat_t: public nodeMaterial_t
 {
 	public:
-		glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diffuse);
+		glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diffuse, bool bCastShadows);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		static material_t* factory(paraMap_t &, std::list< paraMap_t > &, renderEnvironment_t &);
+		virtual bool castShadows() const { return mCastShadows; }
 
 		struct MDat_t
 		{
@@ -60,11 +61,12 @@ class glossyMat_t: public nodeMaterial_t
 		bool as_diffuse, with_diffuse, anisotropic;
 		bool orenNayar;
 		float orenA, orenB;
+		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
 };
 
-glossyMat_t::glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diff):
+glossyMat_t::glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diff, bool bCastShadows):
 			diffuseS(0), glossyS(0), glossyRefS(0), bumpS(0), gloss_color(col), diff_color(dcol), exponent(expo),
-			reflectivity(reflect), mDiffuse(diff), as_diffuse(as_diff), with_diffuse(false), anisotropic(false)
+			reflectivity(reflect), mDiffuse(diff), as_diffuse(as_diff), with_diffuse(false), anisotropic(false), mCastShadows(bCastShadows)
 {
 	bsdfFlags = BSDF_NONE;
 
@@ -360,6 +362,7 @@ material_t* glossyMat_t::factory(paraMap_t &params, std::list< paraMap_t > &para
 	float exponent=50.f; //wild guess, do sth better
 	bool as_diff=true;
 	bool aniso=false;
+	bool bCastShadows=true;
 	const std::string *name=0;
 	params.getParam("color", col);
 	params.getParam("diffuse_color", dcol);
@@ -368,7 +371,8 @@ material_t* glossyMat_t::factory(paraMap_t &params, std::list< paraMap_t > &para
 	params.getParam("as_diffuse", as_diff);
 	params.getParam("exponent", exponent);
 	params.getParam("anisotropic", aniso);
-	glossyMat_t *mat = new glossyMat_t(col, dcol , refl, diff, exponent, as_diff);
+	params.getParam("cast_shadows",     bCastShadows);
+	glossyMat_t *mat = new glossyMat_t(col, dcol , refl, diff, exponent, as_diff, bCastShadows);
 
 	if(aniso)
 	{

--- a/src/materials/glossy2.cc
+++ b/src/materials/glossy2.cc
@@ -30,12 +30,13 @@ __BEGIN_YAFRAY
 class glossyMat_t: public nodeMaterial_t
 {
 	public:
-		glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diffuse);
+		glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diffuse, bool bCastShadows);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		static material_t* factory(paraMap_t &, std::list< paraMap_t > &, renderEnvironment_t &);
+		virtual bool castShadows() const { return mCastShadows; }
 
 		struct MDat_t
 		{
@@ -60,11 +61,12 @@ class glossyMat_t: public nodeMaterial_t
 		bool as_diffuse, with_diffuse, anisotropic;
 		bool orenNayar;
 		float orenA, orenB;
+		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
 };
 
-glossyMat_t::glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diff):
+glossyMat_t::glossyMat_t(const color_t &col, const color_t &dcol, float reflect, float diff, float expo, bool as_diff, bool bCastShadows):
 			diffuseS(0), glossyS(0), glossyRefS(0), bumpS(0), gloss_color(col), diff_color(dcol), exponent(expo),
-			reflectivity(reflect), mDiffuse(diff), as_diffuse(as_diff), with_diffuse(false), anisotropic(false)
+			reflectivity(reflect), mDiffuse(diff), as_diffuse(as_diff), with_diffuse(false), anisotropic(false), mCastShadows(bCastShadows)
 {
 	bsdfFlags = BSDF_NONE;
 
@@ -360,6 +362,7 @@ material_t* glossyMat_t::factory(paraMap_t &params, std::list< paraMap_t > &para
 	float exponent=50.f; //wild guess, do sth better
 	bool as_diff=true;
 	bool aniso=false;
+	bool bCastShadows=true;
 	const std::string *name=0;
 	params.getParam("color", col);
 	params.getParam("diffuse_color", dcol);
@@ -368,7 +371,8 @@ material_t* glossyMat_t::factory(paraMap_t &params, std::list< paraMap_t > &para
 	params.getParam("as_diffuse", as_diff);
 	params.getParam("exponent", exponent);
 	params.getParam("anisotropic", aniso);
-	glossyMat_t *mat = new glossyMat_t(col, dcol , refl, diff, exponent, as_diff);
+	params.getParam("cast_shadows",     bCastShadows);
+	glossyMat_t *mat = new glossyMat_t(col, dcol , refl, diff, exponent, as_diff, bCastShadows);
 
 	if(aniso)
 	{

--- a/src/materials/mask.cc
+++ b/src/materials/mask.cc
@@ -29,8 +29,8 @@
 
 __BEGIN_YAFRAY
 
-maskMat_t::maskMat_t(const material_t *m1, const material_t *m2, CFLOAT thresh):
-	mat1(m1), mat2(m2), threshold(thresh)
+maskMat_t::maskMat_t(const material_t *m1, const material_t *m2, CFLOAT thresh, bool bCastShadows):
+	mat1(m1), mat2(m2), threshold(thresh), mCastShadows(bCastShadows)
 {
 	bsdfFlags = mat1->getFlags() | mat2->getFlags();
 }
@@ -134,6 +134,7 @@ material_t* maskMat_t::factory(paraMap_t &params, std::list< paraMap_t > &eparam
 	const std::string *name = 0;
 	const material_t *m1=0, *m2=0;
 	double thresh = 0.5;
+	bool bCastShadows=true;
 	
 	params.getParam("threshold", thresh);
 	if(! params.getParam("material1", name) ) return 0;
@@ -142,10 +143,11 @@ material_t* maskMat_t::factory(paraMap_t &params, std::list< paraMap_t > &eparam
 	m2 = env.getMaterial(*name);
 	//if(! params.getParam("mask", name) ) return 0;
 	//mask = env.getTexture(*name);
+	params.getParam("cast_shadows",     bCastShadows);
 	
 	if(m1==0 || m2==0 ) return 0;
 	
-	maskMat_t *mat = new maskMat_t(m1, m2, thresh);
+	maskMat_t *mat = new maskMat_t(m1, m2, thresh, bCastShadows);
 	
 	std::vector<shaderNode_t *> roots;
 	if(mat->loadNodes(eparams, env))

--- a/src/materials/roughglass.cc
+++ b/src/materials/roughglass.cc
@@ -27,9 +27,9 @@
 __BEGIN_YAFRAY
 
 
-roughGlassMat_t::roughGlassMat_t(float IOR, color_t filtC, const color_t &srcol, bool fakeS, float alpha, float disp_pow):
+roughGlassMat_t::roughGlassMat_t(float IOR, color_t filtC, const color_t &srcol, bool fakeS, float alpha, float disp_pow, bool bCastShadows):
 		bumpS(0), mirColS(0), filterCol(filtC), specRefCol(srcol), ior(IOR), a2(alpha*alpha), a(alpha), absorb(false),
-		disperse(false), fakeShadow(fakeS)
+		disperse(false), fakeShadow(fakeS), mCastShadows(bCastShadows)
 {
 	bsdfFlags = BSDF_ALL_GLOSSY;
 	if(fakeS) bsdfFlags |= BSDF_FILTER;
@@ -273,6 +273,8 @@ material_t* roughGlassMat_t::factory(paraMap_t &params, std::list< paraMap_t > &
 	color_t filtCol(1.f), absorp(1.f), srCol(1.f);
 	const std::string *name=0;
 	bool fake_shad = false;
+	bool bCastShadows = true;
+	
 	params.getParam("IOR", IOR);
 	params.getParam("filter_color", filtCol);
 	params.getParam("transmit_filter", filt);
@@ -280,10 +282,11 @@ material_t* roughGlassMat_t::factory(paraMap_t &params, std::list< paraMap_t > &
 	params.getParam("alpha", alpha);
 	params.getParam("dispersion_power", disp_power);
 	params.getParam("fake_shadows", fake_shad);
+	params.getParam("cast_shadows",     bCastShadows);
 
 	alpha = std::max(1e-4f, std::min(alpha * 0.5f, 1.f));
 
-	roughGlassMat_t *mat = new roughGlassMat_t(IOR, filt*filtCol + color_t(1.f-filt), srCol, fake_shad, alpha, disp_power);
+	roughGlassMat_t *mat = new roughGlassMat_t(IOR, filt*filtCol + color_t(1.f-filt), srCol, fake_shad, alpha, disp_power, bCastShadows);
 
 	if( params.getParam("absorption", absorp) )
 	{

--- a/src/materials/shinydiffuse.cc
+++ b/src/materials/shinydiffuse.cc
@@ -5,10 +5,10 @@
 
 __BEGIN_YAFRAY
 
-shinyDiffuseMat_t::shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength, float translucencyStrength, float mirrorStrength, float emitStrength, float transmitFilterStrength):
+shinyDiffuseMat_t::shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength, float translucencyStrength, float mirrorStrength, float emitStrength, float transmitFilterStrength, bool bCastShadows):
             mIsTransparent(false), mIsTranslucent(false), mIsMirror(false), mIsDiffuse(false), mHasFresnelEffect(false),
             mDiffuseShader(0), mBumpShader(0), mTransparencyShader(0), mTranslucencyShader(0), mMirrorShader(0), mMirrorColorShader(0), mDiffuseColor(diffuseColor), mMirrorColor(mirrorColor),
-            mMirrorStrength(mirrorStrength), mTransparencyStrength(transparencyStrength), mTranslucencyStrength(translucencyStrength), mDiffuseStrength(diffuseStrength), mTransmitFilterStrength(transmitFilterStrength), mUseOrenNayar(false), nBSDF(0)
+            mMirrorStrength(mirrorStrength), mTransparencyStrength(transparencyStrength), mTranslucencyStrength(translucencyStrength), mDiffuseStrength(diffuseStrength), mTransmitFilterStrength(transmitFilterStrength), mUseOrenNayar(false), nBSDF(0), mCastShadows(bCastShadows)
 {
     mEmitColor = emitStrength * diffuseColor;
     mEmitStrength = emitStrength;
@@ -471,6 +471,7 @@ material_t* shinyDiffuseMat_t::factory(paraMap_t &params, std::list<paraMap_t> &
     float mirrorStrength=0.f;
     float emitStrength = 0.f;
     bool hasFresnelEffect=false;
+    bool bCastShadows=true;
     double IOR = 1.33;
     double transmitFilterStrength=1.0;
 
@@ -484,9 +485,10 @@ material_t* shinyDiffuseMat_t::factory(paraMap_t &params, std::list<paraMap_t> &
     params.getParam("IOR",              IOR);
     params.getParam("fresnel_effect",   hasFresnelEffect);
     params.getParam("transmit_filter",  transmitFilterStrength);
+    params.getParam("cast_shadows",     bCastShadows);
 
     // !!remember to put diffuse multiplier in material itself!
-    shinyDiffuseMat_t *mat = new shinyDiffuseMat_t(diffuseColor, mirrorColor, diffuseStrength, transparencyStrength, translucencyStrength, mirrorStrength, emitStrength, transmitFilterStrength);
+    shinyDiffuseMat_t *mat = new shinyDiffuseMat_t(diffuseColor, mirrorColor, diffuseStrength, transparencyStrength, translucencyStrength, mirrorStrength, emitStrength, transmitFilterStrength, bCastShadows);
 
     if(hasFresnelEffect)
     {

--- a/src/yafraycore/kdtree.cc
+++ b/src/yafraycore/kdtree.cc
@@ -895,11 +895,9 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFL
 			triangle_t *mp = currNode->onePrimitive;
 			if (mp->intersect(ray, &t_hit, bary))
 			{
-				if(t_hit < dist && t_hit >= shadow_bias ) // '>=' ?
+				const material_t *mat = mp->getMaterial();
+				if(t_hit < dist && t_hit >= shadow_bias && mat->castShadows() ) // '>=' ?
 				{
-					const material_t *mat = mp->getMaterial();
-					if(!mat->castShadows() ) return false;
-
 					*tr = mp;
 					return true;
 				}
@@ -913,11 +911,9 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFL
 				triangle_t *mp = prims[i];
 				if (mp->intersect(ray, &t_hit, bary))
 				{
-					if(t_hit < dist && t_hit >= shadow_bias )
+					const material_t *mat = mp->getMaterial();
+					if(t_hit < dist && t_hit >= shadow_bias && mat->castShadows() )
 					{
-						const material_t *mat = mp->getMaterial();
-						if(!mat->castShadows() ) return false;
-
 						*tr = mp;
 						return true;
 					}

--- a/src/yafraycore/kdtree.cc
+++ b/src/yafraycore/kdtree.cc
@@ -897,6 +897,9 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFL
 			{
 				if(t_hit < dist && t_hit >= shadow_bias ) // '>=' ?
 				{
+					const material_t *mat = mp->getMaterial();
+					if(!mat->castShadows() ) return false;
+
 					*tr = mp;
 					return true;
 				}
@@ -912,6 +915,9 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFL
 				{
 					if(t_hit < dist && t_hit >= shadow_bias )
 					{
+						const material_t *mat = mp->getMaterial();
+						if(!mat->castShadows() ) return false;
+
 						*tr = mp;
 						return true;
 					}
@@ -1037,7 +1043,7 @@ bool triKdTree_t::IntersectTS(renderState_t &state, const ray_t &ray, int maxDep
 				if(t_hit < dist && t_hit >= shadow_bias ) // '>=' ?
 				{
 					const material_t *mat = mp->getMaterial();
-					
+					if(!mat->castShadows() ) return false;
 					if(!mat->isTransparent() ) return true;
 					
 					if(filtered.insert(mp).second)
@@ -1063,7 +1069,7 @@ bool triKdTree_t::IntersectTS(renderState_t &state, const ray_t &ray, int maxDep
 					if(t_hit < dist && t_hit >= shadow_bias)
 					{
 						const material_t *mat = mp->getMaterial();
-
+						if(!mat->castShadows() ) return false;
 						if(!mat->isTransparent() ) return true;
 
 						if(filtered.insert(mp).second)


### PR DESCRIPTION
As requested in http://www.yafaray.org/node/665 a new Material parameter has been added to enable/disable casting shadows. The default value is to be enabled, as that's the expected behavior for all objects in a scene. However, if certain objects need to be created shadowless (like in some architectural images), then shadow casting can be disabled in a per-material basis.

 Changes to be committed:
	modified:   include/core_api/material.h
	modified:   include/materials/blendmat.h
	modified:   include/materials/maskmat.h
	modified:   include/materials/roughglass.h
	modified:   include/materials/shinydiff.h
	modified:   src/materials/blend.cc
	modified:   src/materials/coatedglossy.cc
	modified:   src/materials/glass.cc
	modified:   src/materials/glossy.cc
	modified:   src/materials/glossy2.cc
	modified:   src/materials/mask.cc
	modified:   src/materials/roughglass.cc
	modified:   src/materials/shinydiffuse.cc
	modified:   src/yafraycore/kdtree.cc