### PR TITLE
Fix for attenuation when using 2 or more volumetric objects

### DIFF
--- a/src/integrators/SingleScatterIntegrator.cc
+++ b/src/integrators/SingleScatterIntegrator.cc
@@ -181,7 +181,7 @@ public:
 							{
 								VolumeRegion* vr = listVR.at(i);
 								float t0Tmp = -1, t1Tmp = -1;
-								if (vr->intersect(lightRay, t0Tmp, t1Tmp)) lightTr += vr->attenuation(sp.P, (*l)) * iVRSize;
+								if (vr->intersect(lightRay, t0Tmp, t1Tmp)) lightTr += vr->attenuation(sp.P, (*l));
 							}
 						}
 						else
@@ -194,14 +194,12 @@ public:
 								float t0Tmp = -1, t1Tmp = -1;
 								if (listVR.at(i)->intersect(lightRay, t0Tmp, t1Tmp))
 								{
-									lightstepTau += vr->tau(lightRay, currentStep, 0.f) * iVRSize;
+									lightstepTau += vr->tau(lightRay, currentStep, 0.f);
 								}
 							}
 							// transmittance from the point p in the volume to the light (i.e. how much light reaches p)
 							lightTr = fExp(-lightstepTau.energy());
 						}
-						lightTr *= iVRSize;
-
 						inScatter += lightTr * lcol;
 					}
 				}
@@ -239,7 +237,7 @@ public:
 									float t0Tmp = -1, t1Tmp = -1;
 									if (vr->intersect(lightRay, t0Tmp, t1Tmp))
 									{
-										lightTr += vr->attenuation(sp.P, (*l)) * iVRSize;
+										lightTr += vr->attenuation(sp.P, (*l));
 										break;
 									}
 								}
@@ -258,12 +256,11 @@ public:
 									}
 								}
 								// transmittance from the point p in the volume to the light (i.e. how much light reaches p)
-								lightTr += fExp(-lightstepTau.energy()) * iVRSize;
+								lightTr += fExp(-lightstepTau.energy());
 							}
 
 						}
 					}
-					lightTr *= iVRSize;
 				} // end of area light sample loop
 
 				lightTr *= iN;


### PR DESCRIPTION
Reported in bug tracker:
http://yafaray.org/node/332

This is a very old problem. I'm not 100% sure that what I've done is correct, but in my opinion having different attenuation in the volumetric objects depending on how many volumes you have do not seem right to me.

The problem is that, in the SingleScatterIntegrator, for some reason, the attenuation is calculated depending on the number of Volume Regions in the scene. I don't understand why was it done that way, maybe there is a reason for it??

In any case, to fix the problem mentioned in the bugtracker and having the same attenuation independently of the number of volumes in the scene, I've modified the code as you can see in this commit.

Probably a deeper review is needed before this is merged into YafaRay master.

 Changes to be committed:
	modified:   src/integrators/SingleScatterIntegrator.cc