### PR TITLE
New Color Pipeline workflow

### DIFF
--- a/include/core_api/color.h
+++ b/include/core_api/color.h
@@ -3,7 +3,7 @@
  * 			color.h: Color type and operators api
  *      This is part of the yafray package
  *      Copyright (C) 2002  Alejandro Conty Estévez
- *		Copyright (C) 2015  David Bluecame for Color Space additions
+ *      Copyright (C) 2015  David Bluecame for Color Space additions
  *
  *      This library is free software; you can redistribute it and/or
  *      modify it under the terms of the GNU Lesser General Public
@@ -44,10 +44,10 @@ __BEGIN_YAFRAY
 
 enum colorSpaces_t
 {
-	LINEAR_RGB,
-	SRGB,
-	XYZ_D65,
-	RAW_MANUAL_GAMMA
+	RAW_MANUAL_GAMMA	= 1,
+	LINEAR_RGB		= 2,
+	SRGB			= 3,
+	XYZ_D65			= 4	
 };
 
 class YAFRAYCORE_EXPORT color_t

--- a/include/core_api/imagefilm.h
+++ b/include/core_api/imagefilm.h
@@ -107,8 +107,8 @@ class YAFRAYCORE_EXPORT imageFilm_t
 		void setNumSamples(int n){ numSamples = n; }
 		/*! Enables/disables color clamping */
 		void setClamp(bool c){ clamp = c; }
-		/*! Enables/disables gamma correction of output; when gammaVal is <= 0 the current value is kept */
-		void setGamma(float gammaVal, bool enable);
+		/*! Sets the film color space and gamma correction */
+		void setColorSpace(colorSpaces_t color_space, float gammaVal);
 		/*! Sets the adaptative AA sampling threshold */
 		void setAAThreshold(CFLOAT thresh){ AA_thesh=thresh; }
 		/*! Enables interactive color buffer output for preview during render */
@@ -139,6 +139,7 @@ class YAFRAYCORE_EXPORT imageFilm_t
 		int w, h, cx0, cx1, cy0, cy1;
 		int area_cnt, completed_cnt;
 		volatile int next_area;
+		colorSpaces_t colorSpace;
 		float gamma;
 		CFLOAT AA_thesh;
 		float filterw, tableScale;
@@ -146,7 +147,7 @@ class YAFRAYCORE_EXPORT imageFilm_t
 		colorOutput_t *output;
 		// Thread mutes for shared access
 		yafthreads::mutex_t imageMutex, splitterMutex, outMutex, depthMapMutex, densityImageMutex;
-		bool clamp, split, interactive, abort, correctGamma;
+		bool clamp, split, interactive, abort;
 		bool estimateDensity;
 		int numSamples;
 		imageSpliter_t *splitter;

--- a/include/core_api/imagefilm.h
+++ b/include/core_api/imagefilm.h
@@ -107,6 +107,8 @@ class YAFRAYCORE_EXPORT imageFilm_t
 		void setNumSamples(int n){ numSamples = n; }
 		/*! Enables/disables color clamping */
 		void setClamp(bool c){ clamp = c; }
+		/*! (Deprecated, use setColorSpace instead) Enables/disables gamma correction of output; when gammaVal is <= 0 the current value is kept */
+		void setGamma(float gammaVal, bool enable);
 		/*! Sets the film color space and gamma correction */
 		void setColorSpace(colorSpaces_t color_space, float gammaVal);
 		/*! Sets the adaptative AA sampling threshold */

--- a/include/core_api/texture.h
+++ b/include/core_api/texture.h
@@ -17,6 +17,8 @@ class YAFRAYCORE_EXPORT texture_t
 		virtual bool isNormalmap() const { return false; }
 		virtual colorA_t getColor(const point3d_t &p) const = 0;
 		virtual colorA_t getColor(int x, int y, int z) const { return colorA_t(0.f); }
+		virtual colorA_t getNoGammaColor(const point3d_t &p) const { return getColor(p); }	//deprecated: use getRawColor instead
+		virtual colorA_t getNoGammaColor(int x, int y, int z) const { return getColor(x, y, z); }	//deprecated: use getRawColor instead
 		virtual colorA_t getRawColor(const point3d_t &p) const { return getColor(p); }
 		virtual colorA_t getRawColor(int x, int y, int z) const { return getColor(x, y, z); }
 		virtual CFLOAT getFloat(const point3d_t &p) const { return getRawColor(p).col2bri(); }

--- a/include/core_api/texture.h
+++ b/include/core_api/texture.h
@@ -17,10 +17,10 @@ class YAFRAYCORE_EXPORT texture_t
 		virtual bool isNormalmap() const { return false; }
 		virtual colorA_t getColor(const point3d_t &p) const = 0;
 		virtual colorA_t getColor(int x, int y, int z) const { return colorA_t(0.f); }
-		virtual colorA_t getNoGammaColor(const point3d_t &p) const { return getColor(p); }
-		virtual colorA_t getNoGammaColor(int x, int y, int z) const { return getColor(x, y, z); }
-		virtual CFLOAT getFloat(const point3d_t &p) const { return getNoGammaColor(p).col2bri(); }
-		virtual CFLOAT getFloat(int x, int y, int z) const { return getNoGammaColor(x, y, z).col2bri(); }
+		virtual colorA_t getRawColor(const point3d_t &p) const { return getColor(p); }
+		virtual colorA_t getRawColor(int x, int y, int z) const { return getColor(x, y, z); }
+		virtual CFLOAT getFloat(const point3d_t &p) const { return getRawColor(p).col2bri(); }
+		virtual CFLOAT getFloat(int x, int y, int z) const { return getRawColor(x, y, z).col2bri(); }
 		/* gives the number of values in each dimension for discrete textures */
 		virtual void resolution(int &x, int &y, int &z) const { x=0, y=0, z=0; }
 		virtual void getInterpolationStep(float &step) const { step = 0.f; };

--- a/include/interface/xmlinterface.h
+++ b/include/interface/xmlinterface.h
@@ -46,6 +46,9 @@ class YAFRAYPLUGIN_EXPORT xmlInterface_t: public yafrayInterface_t
 		virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
 		
 		virtual void setOutfile(const char *fname);
+		
+		void setXMLColorSpace(std::string color_space_string, float gammaVal);
+		
 	protected:
 		void writeParamMap(const paraMap_t &pmap, int indent=1);
 		void writeParamList(int indent);
@@ -57,6 +60,8 @@ class YAFRAYPLUGIN_EXPORT xmlInterface_t: public yafrayInterface_t
 		size_t nmat;
 		int n_uvs;
 		unsigned int nextObj;
+		float XMLGamma;
+		colorSpaces_t XMLColorSpace;
 };
 
 typedef xmlInterface_t * xmlInterfaceConstructor();

--- a/include/interface/yafrayinterface.h
+++ b/include/interface/yafrayinterface.h
@@ -85,6 +85,7 @@ class YAFRAYPLUGIN_EXPORT yafrayInterface_t
 		virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
 		virtual void render(colorOutput_t &output, progressBar_t *pb = 0); //!< render the scene...
 		virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
+		virtual void setInputGamma(float gammaVal, bool enable);	//deprecated: use setInputColorSpace instead
 		virtual void abort();
 		virtual paraMap_t* getRenderParameters() { return params; }
 		virtual bool getRenderedImage(colorOutput_t &output); //!< put the rendered image to output

--- a/include/interface/yafrayinterface.h
+++ b/include/interface/yafrayinterface.h
@@ -7,6 +7,7 @@
 #include <list>
 #include <vector>
 #include <string>
+#include <core_api/color.h>
 
 
 __BEGIN_YAFRAY
@@ -84,7 +85,6 @@ class YAFRAYPLUGIN_EXPORT yafrayInterface_t
 		virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
 		virtual void render(colorOutput_t &output, progressBar_t *pb = 0); //!< render the scene...
 		virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
-		virtual void setInputGamma(float gammaVal, bool enable);
 		virtual void abort();
 		virtual paraMap_t* getRenderParameters() { return params; }
 		virtual bool getRenderedImage(colorOutput_t &output); //!< put the rendered image to output
@@ -109,6 +109,8 @@ class YAFRAYPLUGIN_EXPORT yafrayInterface_t
 		void printWarning(const std::string &msg);
 		void printError(const std::string &msg);
 		void printLog(const std::string &msg);
+		
+		void setInputColorSpace(std::string color_space_string, float gammaVal);
 	
 	protected:
 		paraMap_t *params;
@@ -118,7 +120,7 @@ class YAFRAYPLUGIN_EXPORT yafrayInterface_t
 		scene_t *scene;
 		imageFilm_t *film;
 		float inputGamma;
-		bool gcInput;
+		colorSpaces_t inputColorSpace;
 };
 
 typedef yafrayInterface_t * interfaceConstructor();

--- a/include/textures/imagetex.h
+++ b/include/textures/imagetex.h
@@ -49,7 +49,7 @@ enum interpolationType
 class textureImage_t : public texture_t
 {
 	public:
-		textureImage_t(imageHandler_t *ih, interpolationType intp, colorSpaces_t color_space, float gamma);
+		textureImage_t(imageHandler_t *ih, interpolationType intp, float gamma, colorSpaces_t color_space = RAW_MANUAL_GAMMA);
 		virtual ~textureImage_t();
 		virtual bool discrete() const { return true; }
 		virtual bool isThreeD() const { return false; }

--- a/include/textures/imagetex.h
+++ b/include/textures/imagetex.h
@@ -49,15 +49,15 @@ enum interpolationType
 class textureImage_t : public texture_t
 {
 	public:
-		textureImage_t(imageHandler_t *ih, interpolationType intp, float gamma);
+		textureImage_t(imageHandler_t *ih, interpolationType intp, colorSpaces_t color_space, float gamma);
 		virtual ~textureImage_t();
 		virtual bool discrete() const { return true; }
 		virtual bool isThreeD() const { return false; }
 		virtual bool isNormalmap() const { return normalmap; }
 		virtual colorA_t getColor(const point3d_t &sp) const;
 		virtual colorA_t getColor(int x, int y, int z) const;
-		virtual colorA_t getNoGammaColor(const point3d_t &p) const;
-		virtual colorA_t getNoGammaColor(int x, int y, int z) const;
+		virtual colorA_t getRawColor(const point3d_t &p) const;
+		virtual colorA_t getRawColor(int x, int y, int z) const;
 		virtual void resolution(int &x, int &y, int &z) const;
 		static texture_t *factory(paraMap_t &params,renderEnvironment_t &render);
 
@@ -74,6 +74,7 @@ class textureImage_t : public texture_t
 		int tex_clipmode;
 		imageHandler_t *image;
 		interpolationType intp_type;
+		colorSpaces_t colorSpace;
 		float gamma;
 };
 

--- a/include/yafraycore/xmlparser.h
+++ b/include/yafraycore/xmlparser.h
@@ -11,7 +11,7 @@ class scene_t;
 class renderEnvironment_t;
 class xmlParser_t;
 
-YAFRAYCORE_EXPORT bool parse_xml_file(const char *filename, scene_t *scene, renderEnvironment_t *env, paraMap_t &render);
+YAFRAYCORE_EXPORT bool parse_xml_file(const char *filename, scene_t *scene, renderEnvironment_t *env, paraMap_t &render, std::string color_space_string, float input_gamma);
 
 typedef void (*startElement_cb)(xmlParser_t &p, const char *element, const char **attrs);
 typedef void (*endElement_cb)(xmlParser_t &p, const char *element);
@@ -28,7 +28,7 @@ struct parserState_t
 class xmlParser_t
 {
 	public:
-		xmlParser_t(renderEnvironment_t *renv, scene_t *sc, paraMap_t &r);
+		xmlParser_t(renderEnvironment_t *renv, scene_t *sc, paraMap_t &r, colorSpaces_t input_color_space, float input_gamma);
 		void pushState(startElement_cb start, endElement_cb end, void *userdata=0);
 		void popState();
 		void startElement(const char *element, const char **attrs){ ++level; if(current) current->start(*this, element, attrs); }
@@ -37,6 +37,8 @@ class xmlParser_t
 		void setParam(const std::string &name, parameter_t &param){ (*cparams)[name] = param; }
 		int currLevel() const{ return level; }
 		int stateLevel() const { return current ? current->level : -1; }
+		colorSpaces_t getInputColorSpace() const { return inputColorSpace; }
+		float getInputGamma() const { return inputGamma; }
 		
 		renderEnvironment_t *env;
 		scene_t *scene;
@@ -47,6 +49,8 @@ class xmlParser_t
 		std::vector<parserState_t> state_stack;
 		parserState_t *current;
 		int level;
+		float inputGamma;
+		colorSpaces_t inputColorSpace;
 };
 
 // state callbacks:

--- a/src/bindings/yafrayinterface.i
+++ b/src/bindings/yafrayinterface.i
@@ -680,147 +680,151 @@ namespace yafaray
 
 		// Interfaces
 
-	class yafrayInterface_t
-	{
-		public:
-			yafrayInterface_t();
-			virtual ~yafrayInterface_t();
-			// directly related to scene_t:
-			virtual void loadPlugins(const char *path); //!< load plugins from path, if NULL load from default path, if available.
-			virtual bool startGeometry(); //!< call before creating geometry; only meshes and vmaps can be created in this state
-			virtual bool endGeometry(); //!< call after creating geometry;
-			/*! start a triangle mesh
-				in this state only vertices, UVs and triangles can be created
-				\param id returns the ID of the created mesh
-			*/
-			virtual unsigned int getNextFreeID();
-			virtual bool startTriMesh(unsigned int id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
-			virtual bool startCurveMesh(unsigned int id, int vertices);
-			virtual bool startTriMeshPtr(unsigned int *id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
-			virtual bool endTriMesh(); //!< end current mesh and return to geometry state
-			virtual bool endCurveMesh(const material_t *mat, float strandStart, float strandEnd, float strandShape); //!< end current mesh and return to geometry state
-			virtual int  addVertex(double x, double y, double z); //!< add vertex to mesh; returns index to be used for addTriangle
-			virtual int  addVertex(double x, double y, double z, double ox, double oy, double oz); //!< add vertex with Orco to mesh; returns index to be used for addTriangle
-			virtual void addNormal(double nx, double ny, double nz); //!< add vertex normal to mesh; the vertex that will be attached to is the last one inserted by addVertex method
-			virtual bool addTriangle(int a, int b, int c, const material_t *mat); //!< add a triangle given vertex indices and material pointer
-			virtual bool addTriangle(int a, int b, int c, int uv_a, int uv_b, int uv_c, const material_t *mat); //!< add a triangle given vertex and uv indices and material pointer
-			virtual int  addUV(float u, float v); //!< add a UV coordinate pair; returns index to be used for addTriangle
-			virtual bool smoothMesh(unsigned int id, double angle); //!< smooth vertex normals of mesh with given ID and angle (in degrees)
-			virtual bool addInstance(unsigned int baseObjectId, matrix4x4_t objToWorld);
-			// functions to build paramMaps instead of passing them from Blender
-			// (decouling implementation details of STL containers, paraMap_t etc. as much as possible)
-			virtual void paramsSetPoint(const char* name, double x, double y, double z);
-			virtual void paramsSetString(const char* name, const char* s);
-			virtual void paramsSetBool(const char* name, bool b);
-			virtual void paramsSetInt(const char* name, int i);
-			virtual void paramsSetFloat(const char* name, double f);
-			virtual void paramsSetColor(const char* name, float r, float g, float b, float a=1.f);
-			virtual void paramsSetColor(const char* name, float *rgb, bool with_alpha=false);
-			virtual void paramsSetMatrix(const char* name, float m[4][4], bool transpose=false);
-			virtual void paramsSetMatrix(const char* name, double m[4][4], bool transpose=false);
-			virtual void paramsSetMemMatrix(const char* name, float* matrix, bool transpose=false);
-			virtual void paramsSetMemMatrix(const char* name, double* matrix, bool transpose=false);
-			virtual void paramsClearAll(); 	//!< clear the paramMap and paramList
-			virtual void paramsStartList(); //!< start writing parameters to the extended paramList (used by materials)
-			virtual void paramsPushList(); 	//!< push new list item in paramList (e.g. new shader node description)
-			virtual void paramsEndList(); 	//!< revert to writing to normal paramMap
-			// functions directly related to renderEnvironment_t
-			virtual light_t* 		createLight			(const char* name);
-			virtual texture_t* 		createTexture		(const char* name);
-			virtual material_t* 	createMaterial		(const char* name);
-			virtual camera_t* 		createCamera		(const char* name);
-			virtual background_t* 	createBackground	(const char* name);
-			virtual integrator_t* 	createIntegrator	(const char* name);
-			virtual VolumeRegion* 	createVolumeRegion	(const char* name);
-			virtual imageHandler_t*	createImageHandler	(const char* name, bool addToTable = true); //!< The addToTable parameter, if true, allows to avoid the interface from taking ownership of the image handler
-			virtual unsigned int 	createObject		(const char* name);
-			virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
-			virtual void render(colorOutput_t &output, progressBar_t *pb = 0); //!< render the scene...
-			virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
-			virtual void setInputGamma(float gammaVal, bool enable);
-			virtual void abort();
-			virtual paraMap_t* getRenderParameters() { return params; }
-			virtual bool getRenderedImage(colorOutput_t &output); //!< put the rendered image to output
-			virtual std::vector<std::string> listImageHandlers();
-			virtual std::vector<std::string> listImageHandlersFullName();
-			virtual std::string getImageFormatFromFullName(const std::string &fullname);
-			virtual std::string getImageFullNameFromFormat(const std::string &format);
+		class yafrayInterface_t
+		{
+			public:
+				yafrayInterface_t();
+				virtual ~yafrayInterface_t();
+				// directly related to scene_t:
+				virtual void loadPlugins(const char *path); //!< load plugins from path, if NULL load from default path, if available.
+				virtual bool startGeometry(); //!< call before creating geometry; only meshes and vmaps can be created in this state
+				virtual bool endGeometry(); //!< call after creating geometry;
+				/*! start a triangle mesh
+					in this state only vertices, UVs and triangles can be created
+					\param id returns the ID of the created mesh
+				*/
+				virtual unsigned int getNextFreeID();
+				virtual bool startTriMesh(unsigned int id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
+				virtual bool startCurveMesh(unsigned int id, int vertices);
+				virtual bool startTriMeshPtr(unsigned int *id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
+				virtual bool endTriMesh(); //!< end current mesh and return to geometry state
+				virtual bool endCurveMesh(const material_t *mat, float strandStart, float strandEnd, float strandShape); //!< end current mesh and return to geometry state
+				virtual int  addVertex(double x, double y, double z); //!< add vertex to mesh; returns index to be used for addTriangle
+				virtual int  addVertex(double x, double y, double z, double ox, double oy, double oz); //!< add vertex with Orco to mesh; returns index to be used for addTriangle
+				virtual void addNormal(double nx, double ny, double nz); //!< add vertex normal to mesh; the vertex that will be attached to is the last one inserted by addVertex method
+				virtual bool addTriangle(int a, int b, int c, const material_t *mat); //!< add a triangle given vertex indices and material pointer
+				virtual bool addTriangle(int a, int b, int c, int uv_a, int uv_b, int uv_c, const material_t *mat); //!< add a triangle given vertex and uv indices and material pointer
+				virtual int  addUV(float u, float v); //!< add a UV coordinate pair; returns index to be used for addTriangle
+				virtual bool smoothMesh(unsigned int id, double angle); //!< smooth vertex normals of mesh with given ID and angle (in degrees)
+				virtual bool addInstance(unsigned int baseObjectId, matrix4x4_t objToWorld);
+				// functions to build paramMaps instead of passing them from Blender
+				// (decouling implementation details of STL containers, paraMap_t etc. as much as possible)
+				virtual void paramsSetPoint(const char* name, double x, double y, double z);
+				virtual void paramsSetString(const char* name, const char* s);
+				virtual void paramsSetBool(const char* name, bool b);
+				virtual void paramsSetInt(const char* name, int i);
+				virtual void paramsSetFloat(const char* name, double f);
+				virtual void paramsSetColor(const char* name, float r, float g, float b, float a=1.f);
+				virtual void paramsSetColor(const char* name, float *rgb, bool with_alpha=false);
+				virtual void paramsSetMatrix(const char* name, float m[4][4], bool transpose=false);
+				virtual void paramsSetMatrix(const char* name, double m[4][4], bool transpose=false);
+				virtual void paramsSetMemMatrix(const char* name, float* matrix, bool transpose=false);
+				virtual void paramsSetMemMatrix(const char* name, double* matrix, bool transpose=false);
+				virtual void paramsClearAll(); 	//!< clear the paramMap and paramList
+				virtual void paramsStartList(); //!< start writing parameters to the extended paramList (used by materials)
+				virtual void paramsPushList(); 	//!< push new list item in paramList (e.g. new shader node description)
+				virtual void paramsEndList(); 	//!< revert to writing to normal paramMap
+				// functions directly related to renderEnvironment_t
+				virtual light_t* 		createLight			(const char* name);
+				virtual texture_t* 		createTexture		(const char* name);
+				virtual material_t* 	createMaterial		(const char* name);
+				virtual camera_t* 		createCamera		(const char* name);
+				virtual background_t* 	createBackground	(const char* name);
+				virtual integrator_t* 	createIntegrator	(const char* name);
+				virtual VolumeRegion* 	createVolumeRegion	(const char* name);
+				virtual imageHandler_t*	createImageHandler	(const char* name, bool addToTable = true); //!< The addToTable parameter, if true, allows to avoid the interface from taking ownership of the image handler
+				virtual unsigned int 	createObject		(const char* name);
+				virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
+				virtual void render(colorOutput_t &output, progressBar_t *pb = 0); //!< render the scene...
+				virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
+				virtual void abort();
+				virtual paraMap_t* getRenderParameters() { return params; }
+				virtual bool getRenderedImage(colorOutput_t &output); //!< put the rendered image to output
+				virtual std::vector<std::string> listImageHandlers();
+				virtual std::vector<std::string> listImageHandlersFullName();
+				virtual std::string getImageFormatFromFullName(const std::string &fullname);
+				virtual std::string getImageFullNameFromFormat(const std::string &format);
+				
+				virtual void setVerbosityLevel(int vlevel);
+				virtual void setVerbosityInfo();
+				virtual void setVerbosityWarning();
+				virtual void setVerbosityError();
+				virtual void setVerbosityMute();
+				
+				virtual void setDrawParams(bool on = true);
+				virtual bool getDrawParams();
 
-			virtual void setVerbosityLevel(int vlevel);
-			virtual void setVerbosityInfo();
-			virtual void setVerbosityWarning();
-			virtual void setVerbosityError();
-			virtual void setVerbosityMute();
+				virtual char* getVersion() const; //!< Get version to check aginst the exporters
+				
+				/*! Console Printing wrappers to report in color with yafaray's own console coloring */
+				void printInfo(const std::string &msg);
+				void printWarning(const std::string &msg);
+				void printError(const std::string &msg);
+				void printLog(const std::string &msg);
+				
+				void setInputColorSpace(std::string color_space_string, float gammaVal);
+			
+			protected:
+				paraMap_t *params;
+				std::list<paraMap_t> *eparams; //! for materials that need to define a whole shader tree etc.
+				paraMap_t *cparams; //! just a pointer to the current paramMap, either params or a eparams element
+				renderEnvironment_t *env;
+				scene_t *scene;
+				imageFilm_t *film;
+				float inputGamma;
+				colorSpaces_t inputColorSpace;
+		};
 
-			virtual void setDrawParams(bool on = true);
-			virtual bool getDrawParams();
-
-			virtual char* getVersion() const; //!< Get version to check aginst the exporters
-
-			/*! Console Printing wrappers to report in color with yafaray's own console coloring */
-			void printInfo(const std::string &msg);
-			void printWarning(const std::string &msg);
-			void printError(const std::string &msg);
-			void printLog(const std::string &msg);
-
-		protected:
-			paraMap_t *params;
-			std::list<paraMap_t> *eparams; //! for materials that need to define a whole shader tree etc.
-			paraMap_t *cparams; //! just a pointer to the current paramMap, either params or a eparams element
-			renderEnvironment_t *env;
-			scene_t *scene;
-			imageFilm_t *film;
-			float inputGamma;
-			bool gcInput;
-	};
-
-
-	class xmlInterface_t: public yafrayInterface_t
-	{
-		public:
-			xmlInterface_t();
-			// directly related to scene_t:
-			virtual void loadPlugins(const char *path);
-			virtual bool startGeometry();
-			virtual bool endGeometry();
-			virtual unsigned int getNextFreeID();
-			virtual bool startTriMesh(unsigned int id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
-			virtual bool startCurveMesh(unsigned int id, int vertices);
-			virtual bool startTriMeshPtr(unsigned int *id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
-			virtual bool endTriMesh();
-			virtual bool endCurveMesh(const material_t *mat, float strandStart, float strandEnd, float strandShape); //!< end current mesh and return to geometry state
-			virtual int  addVertex(double x, double y, double z); //!< add vertex to mesh; returns index to be used for addTriangle
-			virtual int  addVertex(double x, double y, double z, double ox, double oy, double oz); //!< add vertex with Orco to mesh; returns index to be used for addTriangle
-			virtual void addNormal(double nx, double ny, double nz); //!< add vertex normal to mesh; the vertex that will be attached to is the last one inserted by addVertex method
-			virtual bool addTriangle(int a, int b, int c, const material_t *mat);
-			virtual bool addTriangle(int a, int b, int c, int uv_a, int uv_b, int uv_c, const material_t *mat);
-			virtual int  addUV(float u, float v);
-			virtual bool smoothMesh(unsigned int id, double angle);
-
-			// functions directly related to renderEnvironment_t
-			virtual light_t* 		createLight		(const char* name);
-			virtual texture_t* 		createTexture	(const char* name);
-			virtual material_t* 	createMaterial	(const char* name);
-			virtual camera_t* 		createCamera	(const char* name);
-			virtual background_t* 	createBackground(const char* name);
-			virtual integrator_t* 	createIntegrator(const char* name);
-			virtual unsigned int 	createObject	(const char* name);
-			virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
-			virtual void render(colorOutput_t &output); //!< render the scene...
-			virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
-
-			virtual void setOutfile(const char *fname);
-		protected:
-			void writeParamMap(const paramMap_t &pmap, int indent=1);
-			void writeParamList(int indent);
-
-			std::map<const material_t *, std::string> materials;
-			std::ofstream xmlFile;
-			std::string xmlName;
-			const material_t *last_mat;
-			size_t nmat;
-			int n_uvs;
-			unsigned int nextObj;
-	};
+		class xmlInterface_t: public yafrayInterface_t
+		{
+			public:
+				xmlInterface_t();
+				// directly related to scene_t:
+				virtual void loadPlugins(const char *path);
+				virtual bool startGeometry();
+				virtual bool endGeometry();
+				virtual unsigned int getNextFreeID();
+				virtual bool startTriMesh(unsigned int id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
+				virtual bool startTriMeshPtr(unsigned int *id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
+				virtual bool startCurveMesh(unsigned int id, int vertices);
+				virtual bool endTriMesh();
+				virtual bool addInstance(unsigned int baseObjectId, matrix4x4_t objToWorld);
+				virtual bool endCurveMesh(const material_t *mat, float strandStart, float strandEnd, float strandShape);
+				virtual int  addVertex(double x, double y, double z); //!< add vertex to mesh; returns index to be used for addTriangle
+				virtual int  addVertex(double x, double y, double z, double ox, double oy, double oz); //!< add vertex with Orco to mesh; returns index to be used for addTriangle
+				virtual void addNormal(double nx, double ny, double nz); //!< add vertex normal to mesh; the vertex that will be attached to is the last one inserted by addVertex method
+				virtual bool addTriangle(int a, int b, int c, const material_t *mat);
+				virtual bool addTriangle(int a, int b, int c, int uv_a, int uv_b, int uv_c, const material_t *mat);
+				virtual int  addUV(float u, float v);
+				virtual bool smoothMesh(unsigned int id, double angle);
+				
+				// functions directly related to renderEnvironment_t
+				virtual light_t* 		createLight			(const char* name);
+				virtual texture_t* 		createTexture		(const char* name);
+				virtual material_t* 	createMaterial		(const char* name);
+				virtual camera_t* 		createCamera		(const char* name);
+				virtual background_t* 	createBackground	(const char* name);
+				virtual integrator_t* 	createIntegrator	(const char* name);
+				virtual VolumeRegion* 	createVolumeRegion	(const char* name);
+				virtual unsigned int 	createObject		(const char* name);
+				virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
+				virtual void render(colorOutput_t &output); //!< render the scene...
+				virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
+				virtual void setOutfile(const char *fname);
+				void xmlInterface_t::setXMLColorSpace(std::string color_space_string, float gammaVal);
+			protected:
+				void writeParamMap(const paraMap_t &pmap, int indent=1);
+				void writeParamList(int indent);
+				
+				std::map<const material_t *, std::string> materials;
+				std::ofstream xmlFile;
+				std::string xmlName;
+				const material_t *last_mat;
+				size_t nmat;
+				int n_uvs;
+				unsigned int nextObj;
+				float XMLGamma;
+				colorSpaces_t XMLColorSpace;
+		};
 
 }

--- a/src/bindings/yafrayinterface.i
+++ b/src/bindings/yafrayinterface.i
@@ -676,155 +676,155 @@ namespace yafaray
 
 			float  matrix[4][4];
 			int _invalid;
-		};
+	};
 
-		// Interfaces
+	// Interfaces
 
-		class yafrayInterface_t
-		{
-			public:
-				yafrayInterface_t();
-				virtual ~yafrayInterface_t();
-				// directly related to scene_t:
-				virtual void loadPlugins(const char *path); //!< load plugins from path, if NULL load from default path, if available.
-				virtual bool startGeometry(); //!< call before creating geometry; only meshes and vmaps can be created in this state
-				virtual bool endGeometry(); //!< call after creating geometry;
-				/*! start a triangle mesh
-					in this state only vertices, UVs and triangles can be created
-					\param id returns the ID of the created mesh
-				*/
-				virtual unsigned int getNextFreeID();
-				virtual bool startTriMesh(unsigned int id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
-				virtual bool startCurveMesh(unsigned int id, int vertices);
-				virtual bool startTriMeshPtr(unsigned int *id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
-				virtual bool endTriMesh(); //!< end current mesh and return to geometry state
-				virtual bool endCurveMesh(const material_t *mat, float strandStart, float strandEnd, float strandShape); //!< end current mesh and return to geometry state
-				virtual int  addVertex(double x, double y, double z); //!< add vertex to mesh; returns index to be used for addTriangle
-				virtual int  addVertex(double x, double y, double z, double ox, double oy, double oz); //!< add vertex with Orco to mesh; returns index to be used for addTriangle
-				virtual void addNormal(double nx, double ny, double nz); //!< add vertex normal to mesh; the vertex that will be attached to is the last one inserted by addVertex method
-				virtual bool addTriangle(int a, int b, int c, const material_t *mat); //!< add a triangle given vertex indices and material pointer
-				virtual bool addTriangle(int a, int b, int c, int uv_a, int uv_b, int uv_c, const material_t *mat); //!< add a triangle given vertex and uv indices and material pointer
-				virtual int  addUV(float u, float v); //!< add a UV coordinate pair; returns index to be used for addTriangle
-				virtual bool smoothMesh(unsigned int id, double angle); //!< smooth vertex normals of mesh with given ID and angle (in degrees)
-				virtual bool addInstance(unsigned int baseObjectId, matrix4x4_t objToWorld);
-				// functions to build paramMaps instead of passing them from Blender
-				// (decouling implementation details of STL containers, paraMap_t etc. as much as possible)
-				virtual void paramsSetPoint(const char* name, double x, double y, double z);
-				virtual void paramsSetString(const char* name, const char* s);
-				virtual void paramsSetBool(const char* name, bool b);
-				virtual void paramsSetInt(const char* name, int i);
-				virtual void paramsSetFloat(const char* name, double f);
-				virtual void paramsSetColor(const char* name, float r, float g, float b, float a=1.f);
-				virtual void paramsSetColor(const char* name, float *rgb, bool with_alpha=false);
-				virtual void paramsSetMatrix(const char* name, float m[4][4], bool transpose=false);
-				virtual void paramsSetMatrix(const char* name, double m[4][4], bool transpose=false);
-				virtual void paramsSetMemMatrix(const char* name, float* matrix, bool transpose=false);
-				virtual void paramsSetMemMatrix(const char* name, double* matrix, bool transpose=false);
-				virtual void paramsClearAll(); 	//!< clear the paramMap and paramList
-				virtual void paramsStartList(); //!< start writing parameters to the extended paramList (used by materials)
-				virtual void paramsPushList(); 	//!< push new list item in paramList (e.g. new shader node description)
-				virtual void paramsEndList(); 	//!< revert to writing to normal paramMap
-				// functions directly related to renderEnvironment_t
-				virtual light_t* 		createLight			(const char* name);
-				virtual texture_t* 		createTexture		(const char* name);
-				virtual material_t* 	createMaterial		(const char* name);
-				virtual camera_t* 		createCamera		(const char* name);
-				virtual background_t* 	createBackground	(const char* name);
-				virtual integrator_t* 	createIntegrator	(const char* name);
-				virtual VolumeRegion* 	createVolumeRegion	(const char* name);
-				virtual imageHandler_t*	createImageHandler	(const char* name, bool addToTable = true); //!< The addToTable parameter, if true, allows to avoid the interface from taking ownership of the image handler
-				virtual unsigned int 	createObject		(const char* name);
-				virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
-				virtual void render(colorOutput_t &output, progressBar_t *pb = 0); //!< render the scene...
-				virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
-				virtual void abort();
-				virtual paraMap_t* getRenderParameters() { return params; }
-				virtual bool getRenderedImage(colorOutput_t &output); //!< put the rendered image to output
-				virtual std::vector<std::string> listImageHandlers();
-				virtual std::vector<std::string> listImageHandlersFullName();
-				virtual std::string getImageFormatFromFullName(const std::string &fullname);
-				virtual std::string getImageFullNameFromFormat(const std::string &format);
-				
-				virtual void setVerbosityLevel(int vlevel);
-				virtual void setVerbosityInfo();
-				virtual void setVerbosityWarning();
-				virtual void setVerbosityError();
-				virtual void setVerbosityMute();
-				
-				virtual void setDrawParams(bool on = true);
-				virtual bool getDrawParams();
-
-				virtual char* getVersion() const; //!< Get version to check aginst the exporters
-				
-				/*! Console Printing wrappers to report in color with yafaray's own console coloring */
-				void printInfo(const std::string &msg);
-				void printWarning(const std::string &msg);
-				void printError(const std::string &msg);
-				void printLog(const std::string &msg);
-				
-				void setInputColorSpace(std::string color_space_string, float gammaVal);
+	class yafrayInterface_t
+	{
+		public:
+			yafrayInterface_t();
+			virtual ~yafrayInterface_t();
+			// directly related to scene_t:
+			virtual void loadPlugins(const char *path); //!< load plugins from path, if NULL load from default path, if available.
+			virtual bool startGeometry(); //!< call before creating geometry; only meshes and vmaps can be created in this state
+			virtual bool endGeometry(); //!< call after creating geometry;
+			/*! start a triangle mesh
+				in this state only vertices, UVs and triangles can be created
+				\param id returns the ID of the created mesh
+			*/
+			virtual unsigned int getNextFreeID();
+			virtual bool startTriMesh(unsigned int id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
+			virtual bool startCurveMesh(unsigned int id, int vertices);
+			virtual bool startTriMeshPtr(unsigned int *id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
+			virtual bool endTriMesh(); //!< end current mesh and return to geometry state
+			virtual bool endCurveMesh(const material_t *mat, float strandStart, float strandEnd, float strandShape); //!< end current mesh and return to geometry state
+			virtual int  addVertex(double x, double y, double z); //!< add vertex to mesh; returns index to be used for addTriangle
+			virtual int  addVertex(double x, double y, double z, double ox, double oy, double oz); //!< add vertex with Orco to mesh; returns index to be used for addTriangle
+			virtual void addNormal(double nx, double ny, double nz); //!< add vertex normal to mesh; the vertex that will be attached to is the last one inserted by addVertex method
+			virtual bool addTriangle(int a, int b, int c, const material_t *mat); //!< add a triangle given vertex indices and material pointer
+			virtual bool addTriangle(int a, int b, int c, int uv_a, int uv_b, int uv_c, const material_t *mat); //!< add a triangle given vertex and uv indices and material pointer
+			virtual int  addUV(float u, float v); //!< add a UV coordinate pair; returns index to be used for addTriangle
+			virtual bool smoothMesh(unsigned int id, double angle); //!< smooth vertex normals of mesh with given ID and angle (in degrees)
+			virtual bool addInstance(unsigned int baseObjectId, matrix4x4_t objToWorld);
+			// functions to build paramMaps instead of passing them from Blender
+			// (decouling implementation details of STL containers, paraMap_t etc. as much as possible)
+			virtual void paramsSetPoint(const char* name, double x, double y, double z);
+			virtual void paramsSetString(const char* name, const char* s);
+			virtual void paramsSetBool(const char* name, bool b);
+			virtual void paramsSetInt(const char* name, int i);
+			virtual void paramsSetFloat(const char* name, double f);
+			virtual void paramsSetColor(const char* name, float r, float g, float b, float a=1.f);
+			virtual void paramsSetColor(const char* name, float *rgb, bool with_alpha=false);
+			virtual void paramsSetMatrix(const char* name, float m[4][4], bool transpose=false);
+			virtual void paramsSetMatrix(const char* name, double m[4][4], bool transpose=false);
+			virtual void paramsSetMemMatrix(const char* name, float* matrix, bool transpose=false);
+			virtual void paramsSetMemMatrix(const char* name, double* matrix, bool transpose=false);
+			virtual void paramsClearAll(); 	//!< clear the paramMap and paramList
+			virtual void paramsStartList(); //!< start writing parameters to the extended paramList (used by materials)
+			virtual void paramsPushList(); 	//!< push new list item in paramList (e.g. new shader node description)
+			virtual void paramsEndList(); 	//!< revert to writing to normal paramMap
+			// functions directly related to renderEnvironment_t
+			virtual light_t* 		createLight			(const char* name);
+			virtual texture_t* 		createTexture		(const char* name);
+			virtual material_t* 	createMaterial		(const char* name);
+			virtual camera_t* 		createCamera		(const char* name);
+			virtual background_t* 	createBackground	(const char* name);
+			virtual integrator_t* 	createIntegrator	(const char* name);
+			virtual VolumeRegion* 	createVolumeRegion	(const char* name);
+			virtual imageHandler_t*	createImageHandler	(const char* name, bool addToTable = true); //!< The addToTable parameter, if true, allows to avoid the interface from taking ownership of the image handler
+			virtual unsigned int 	createObject		(const char* name);
+			virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
+			virtual void render(colorOutput_t &output, progressBar_t *pb = 0); //!< render the scene...
+			virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
+			virtual void abort();
+			virtual paraMap_t* getRenderParameters() { return params; }
+			virtual bool getRenderedImage(colorOutput_t &output); //!< put the rendered image to output
+			virtual std::vector<std::string> listImageHandlers();
+			virtual std::vector<std::string> listImageHandlersFullName();
+			virtual std::string getImageFormatFromFullName(const std::string &fullname);
+			virtual std::string getImageFullNameFromFormat(const std::string &format);
 			
-			protected:
-				paraMap_t *params;
-				std::list<paraMap_t> *eparams; //! for materials that need to define a whole shader tree etc.
-				paraMap_t *cparams; //! just a pointer to the current paramMap, either params or a eparams element
-				renderEnvironment_t *env;
-				scene_t *scene;
-				imageFilm_t *film;
-				float inputGamma;
-				colorSpaces_t inputColorSpace;
-		};
+			virtual void setVerbosityLevel(int vlevel);
+			virtual void setVerbosityInfo();
+			virtual void setVerbosityWarning();
+			virtual void setVerbosityError();
+			virtual void setVerbosityMute();
+			
+			virtual void setDrawParams(bool on = true);
+			virtual bool getDrawParams();
 
-		class xmlInterface_t: public yafrayInterface_t
-		{
-			public:
-				xmlInterface_t();
-				// directly related to scene_t:
-				virtual void loadPlugins(const char *path);
-				virtual bool startGeometry();
-				virtual bool endGeometry();
-				virtual unsigned int getNextFreeID();
-				virtual bool startTriMesh(unsigned int id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
-				virtual bool startTriMeshPtr(unsigned int *id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
-				virtual bool startCurveMesh(unsigned int id, int vertices);
-				virtual bool endTriMesh();
-				virtual bool addInstance(unsigned int baseObjectId, matrix4x4_t objToWorld);
-				virtual bool endCurveMesh(const material_t *mat, float strandStart, float strandEnd, float strandShape);
-				virtual int  addVertex(double x, double y, double z); //!< add vertex to mesh; returns index to be used for addTriangle
-				virtual int  addVertex(double x, double y, double z, double ox, double oy, double oz); //!< add vertex with Orco to mesh; returns index to be used for addTriangle
-				virtual void addNormal(double nx, double ny, double nz); //!< add vertex normal to mesh; the vertex that will be attached to is the last one inserted by addVertex method
-				virtual bool addTriangle(int a, int b, int c, const material_t *mat);
-				virtual bool addTriangle(int a, int b, int c, int uv_a, int uv_b, int uv_c, const material_t *mat);
-				virtual int  addUV(float u, float v);
-				virtual bool smoothMesh(unsigned int id, double angle);
-				
-				// functions directly related to renderEnvironment_t
-				virtual light_t* 		createLight			(const char* name);
-				virtual texture_t* 		createTexture		(const char* name);
-				virtual material_t* 	createMaterial		(const char* name);
-				virtual camera_t* 		createCamera		(const char* name);
-				virtual background_t* 	createBackground	(const char* name);
-				virtual integrator_t* 	createIntegrator	(const char* name);
-				virtual VolumeRegion* 	createVolumeRegion	(const char* name);
-				virtual unsigned int 	createObject		(const char* name);
-				virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
-				virtual void render(colorOutput_t &output); //!< render the scene...
-				virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
-				virtual void setOutfile(const char *fname);
-				void xmlInterface_t::setXMLColorSpace(std::string color_space_string, float gammaVal);
-			protected:
-				void writeParamMap(const paraMap_t &pmap, int indent=1);
-				void writeParamList(int indent);
-				
-				std::map<const material_t *, std::string> materials;
-				std::ofstream xmlFile;
-				std::string xmlName;
-				const material_t *last_mat;
-				size_t nmat;
-				int n_uvs;
-				unsigned int nextObj;
-				float XMLGamma;
-				colorSpaces_t XMLColorSpace;
-		};
+			virtual char* getVersion() const; //!< Get version to check aginst the exporters
+			
+			/*! Console Printing wrappers to report in color with yafaray's own console coloring */
+			void printInfo(const std::string &msg);
+			void printWarning(const std::string &msg);
+			void printError(const std::string &msg);
+			void printLog(const std::string &msg);
+			
+			void setInputColorSpace(std::string color_space_string, float gammaVal);
+		
+		protected:
+			paraMap_t *params;
+			std::list<paraMap_t> *eparams; //! for materials that need to define a whole shader tree etc.
+			paraMap_t *cparams; //! just a pointer to the current paramMap, either params or a eparams element
+			renderEnvironment_t *env;
+			scene_t *scene;
+			imageFilm_t *film;
+			float inputGamma;
+			colorSpaces_t inputColorSpace;
+	};
+
+	class xmlInterface_t: public yafrayInterface_t
+	{
+		public:
+			xmlInterface_t();
+			// directly related to scene_t:
+			virtual void loadPlugins(const char *path);
+			virtual bool startGeometry();
+			virtual bool endGeometry();
+			virtual unsigned int getNextFreeID();
+			virtual bool startTriMesh(unsigned int id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
+			virtual bool startTriMeshPtr(unsigned int *id, int vertices, int triangles, bool hasOrco, bool hasUV=false, int type=0);
+			virtual bool startCurveMesh(unsigned int id, int vertices);
+			virtual bool endTriMesh();
+			virtual bool addInstance(unsigned int baseObjectId, matrix4x4_t objToWorld);
+			virtual bool endCurveMesh(const material_t *mat, float strandStart, float strandEnd, float strandShape);
+			virtual int  addVertex(double x, double y, double z); //!< add vertex to mesh; returns index to be used for addTriangle
+			virtual int  addVertex(double x, double y, double z, double ox, double oy, double oz); //!< add vertex with Orco to mesh; returns index to be used for addTriangle
+			virtual void addNormal(double nx, double ny, double nz); //!< add vertex normal to mesh; the vertex that will be attached to is the last one inserted by addVertex method
+			virtual bool addTriangle(int a, int b, int c, const material_t *mat);
+			virtual bool addTriangle(int a, int b, int c, int uv_a, int uv_b, int uv_c, const material_t *mat);
+			virtual int  addUV(float u, float v);
+			virtual bool smoothMesh(unsigned int id, double angle);
+			
+			// functions directly related to renderEnvironment_t
+			virtual light_t* 		createLight			(const char* name);
+			virtual texture_t* 		createTexture		(const char* name);
+			virtual material_t* 	createMaterial		(const char* name);
+			virtual camera_t* 		createCamera		(const char* name);
+			virtual background_t* 	createBackground	(const char* name);
+			virtual integrator_t* 	createIntegrator	(const char* name);
+			virtual VolumeRegion* 	createVolumeRegion	(const char* name);
+			virtual unsigned int 	createObject		(const char* name);
+			virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
+			virtual void render(colorOutput_t &output); //!< render the scene...
+			virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
+			virtual void setOutfile(const char *fname);
+			void xmlInterface_t::setXMLColorSpace(std::string color_space_string, float gammaVal);
+		protected:
+			void writeParamMap(const paraMap_t &pmap, int indent=1);
+			void writeParamList(int indent);
+			
+			std::map<const material_t *, std::string> materials;
+			std::ofstream xmlFile;
+			std::string xmlName;
+			const material_t *last_mat;
+			size_t nmat;
+			int n_uvs;
+			unsigned int nextObj;
+			float XMLGamma;
+			colorSpaces_t XMLColorSpace;
+	};
 
 }

--- a/src/bindings/yafrayinterface.i
+++ b/src/bindings/yafrayinterface.i
@@ -737,6 +737,7 @@ namespace yafaray
 			virtual void clearAll(); //!< clear the whole environment + scene, i.e. free (hopefully) all memory.
 			virtual void render(colorOutput_t &output, progressBar_t *pb = 0); //!< render the scene...
 			virtual bool startScene(int type=0); //!< start a new scene; Must be called before any of the scene_t related callbacks!
+			virtual void setInputGamma(float gammaVal, bool enable);	//deprecated: use setInputColorSpace instead
 			virtual void abort();
 			virtual paraMap_t* getRenderParameters() { return params; }
 			virtual bool getRenderedImage(colorOutput_t &output); //!< put the rendered image to output

--- a/src/interface/xmlinterface.cc
+++ b/src/interface/xmlinterface.cc
@@ -327,7 +327,7 @@ void xmlInterface_t::setXMLColorSpace(std::string color_space_string, float gamm
 	if(color_space_string == "sRGB") XMLColorSpace = SRGB;
 	else if(color_space_string == "XYZ") XMLColorSpace = XYZ_D65;
 	else if(color_space_string == "LinearRGB") XMLColorSpace = LINEAR_RGB;
-	else if(color_space_string == "Raw_manual_Gamma") XMLColorSpace = RAW_MANUAL_GAMMA;
+	else if(color_space_string == "Raw_Manual_Gamma") XMLColorSpace = RAW_MANUAL_GAMMA;
 	else XMLColorSpace = SRGB;
 	
 	XMLGamma = gammaVal;

--- a/src/interface/xmlinterface.cc
+++ b/src/interface/xmlinterface.cc
@@ -5,7 +5,7 @@
 
 __BEGIN_YAFRAY
 
-xmlInterface_t::xmlInterface_t(): last_mat(0), nextObj(0), XMLGamma(1.f), XMLColorSpace(SRGB)
+xmlInterface_t::xmlInterface_t(): last_mat(0), nextObj(0), XMLGamma(1.f), XMLColorSpace(RAW_MANUAL_GAMMA)
 {
 	xmlName = "yafaray.xml";
 }

--- a/src/interface/yafrayinterface.cc
+++ b/src/interface/yafrayinterface.cc
@@ -8,7 +8,7 @@
 
 __BEGIN_YAFRAY
 
-yafrayInterface_t::yafrayInterface_t(): scene(0), film(0), inputGamma(1.f), gcInput(false)
+yafrayInterface_t::yafrayInterface_t(): scene(0), film(0), inputGamma(1.f), inputColorSpace(LINEAR_RGB)
 {
 	env = new renderEnvironment_t();
 	params = new paraMap_t;
@@ -171,14 +171,14 @@ void yafrayInterface_t::paramsSetFloat(const char* name, double f)
 void yafrayInterface_t::paramsSetColor(const char* name, float r, float g, float b, float a)
 {
 	colorA_t col(r,g,b,a);
-	if(gcInput) col.gammaAdjust(inputGamma);
+	col.linearRGB_from_ColorSpace(inputColorSpace, inputGamma);
 	(*cparams)[std::string(name)] = parameter_t(col);
 }
 
 void yafrayInterface_t::paramsSetColor(const char* name, float *rgb, bool with_alpha)
 {
 	colorA_t col(rgb[0],rgb[1],rgb[2], (with_alpha ? rgb[3] : 1.f));
-	if(gcInput) col.gammaAdjust(inputGamma);
+	col.linearRGB_from_ColorSpace(inputColorSpace, inputGamma);
 	(*cparams)[std::string(name)] = parameter_t(col);
 }
 
@@ -214,10 +214,15 @@ void yafrayInterface_t::paramsSetMemMatrix(const char* name, double* matrix, boo
 	paramsSetMatrix(name, mat, transpose);
 }
 
-void yafrayInterface_t::setInputGamma(float gammaVal, bool enable)
+void yafrayInterface_t::setInputColorSpace(std::string color_space_string, float gammaVal)
 {
-	gcInput = enable;
-	if(gammaVal > 0) inputGamma = gammaVal;
+	if(color_space_string == "sRGB") inputColorSpace = SRGB;
+	else if(color_space_string == "XYZ") inputColorSpace = XYZ_D65;
+	else if(color_space_string == "LinearRGB") inputColorSpace = LINEAR_RGB;
+	else if(color_space_string == "Raw_manual_Gamma") inputColorSpace = RAW_MANUAL_GAMMA;
+	else inputColorSpace = SRGB;
+	
+	inputGamma = gammaVal;
 }
 
 void yafrayInterface_t::paramsClearAll()

--- a/src/interface/yafrayinterface.cc
+++ b/src/interface/yafrayinterface.cc
@@ -8,7 +8,7 @@
 
 __BEGIN_YAFRAY
 
-yafrayInterface_t::yafrayInterface_t(): scene(0), film(0), inputGamma(1.f), inputColorSpace(LINEAR_RGB)
+yafrayInterface_t::yafrayInterface_t(): scene(0), film(0), inputGamma(1.f), inputColorSpace(RAW_MANUAL_GAMMA)
 {
 	env = new renderEnvironment_t();
 	params = new paraMap_t;
@@ -212,6 +212,12 @@ void yafrayInterface_t::paramsSetMemMatrix(const char* name, double* matrix, boo
 		for(j= 0; j < 4; j++)
 			mat[i][j] = *(matrix+i*4+j);
 	paramsSetMatrix(name, mat, transpose);
+}
+
+void yafrayInterface_t::setInputGamma(float gammaVal, bool enable)
+//deprecated: use setInputColorSpace instead
+{
+	setInputColorSpace("Raw_Manual_Gamma", gammaVal);
 }
 
 void yafrayInterface_t::setInputColorSpace(std::string color_space_string, float gammaVal)

--- a/src/interface/yafrayinterface.cc
+++ b/src/interface/yafrayinterface.cc
@@ -219,7 +219,7 @@ void yafrayInterface_t::setInputColorSpace(std::string color_space_string, float
 	if(color_space_string == "sRGB") inputColorSpace = SRGB;
 	else if(color_space_string == "XYZ") inputColorSpace = XYZ_D65;
 	else if(color_space_string == "LinearRGB") inputColorSpace = LINEAR_RGB;
-	else if(color_space_string == "Raw_manual_Gamma") inputColorSpace = RAW_MANUAL_GAMMA;
+	else if(color_space_string == "Raw_Manual_Gamma") inputColorSpace = RAW_MANUAL_GAMMA;
 	else inputColorSpace = SRGB;
 	
 	inputGamma = gammaVal;

--- a/src/textures/basicnodes.cc
+++ b/src/textures/basicnodes.cc
@@ -183,7 +183,7 @@ void textureMapper_t::evalDerivative(nodeStack_t &stack, const renderState_t &st
 		if (tex->isNormalmap())
 		{
 			// Get color from normal map texture
-			color = tex->getNoGammaColor(texpt);
+			color = tex->getRawColor(texpt);
 
 			// Assign normal map RGB colors to vector norm
 			norm.x = color.getR();

--- a/src/textures/imagetex.cc
+++ b/src/textures/imagetex.cc
@@ -26,7 +26,7 @@
 
 __BEGIN_YAFRAY
 
-textureImage_t::textureImage_t(imageHandler_t *ih, interpolationType intp, colorSpaces_t color_space, float gamma):
+textureImage_t::textureImage_t(imageHandler_t *ih, interpolationType intp, float gamma, colorSpaces_t color_space):
 				image(ih), intp_type(intp), colorSpace(color_space), gamma(gamma)
 {
 	// Empty
@@ -257,8 +257,8 @@ texture_t *textureImage_t::factory(paraMap_t &params, renderEnvironment_t &rende
 	double gamma = 1.0;
 	double expadj = 0.0;
 	bool normalmap = false;
-	std::string color_space_string = "sRGB";
-	colorSpaces_t color_space = SRGB;
+	std::string color_space_string = "Raw_Manual_Gamma";
+	colorSpaces_t color_space = RAW_MANUAL_GAMMA;
 	textureImage_t *tex = NULL;
 	imageHandler_t *ih = NULL;
 	params.getParam("interpolate", intpstr);
@@ -330,7 +330,7 @@ texture_t *textureImage_t::factory(paraMap_t &params, renderEnvironment_t &rende
 		else color_space = SRGB;
 	}
 	
-	tex = new textureImage_t(ih, intp, color_space, gamma);
+	tex = new textureImage_t(ih, intp, gamma, color_space);
 
 	if(!tex)
 	{

--- a/src/textures/imagetex.cc
+++ b/src/textures/imagetex.cc
@@ -26,8 +26,8 @@
 
 __BEGIN_YAFRAY
 
-textureImage_t::textureImage_t(imageHandler_t *ih, interpolationType intp, float gamma):
-				image(ih), intp_type(intp), gamma(gamma)
+textureImage_t::textureImage_t(imageHandler_t *ih, interpolationType intp, colorSpaces_t color_space, float gamma):
+				image(ih), intp_type(intp), colorSpace(color_space), gamma(gamma)
 {
 	// Empty
 }
@@ -122,14 +122,12 @@ colorA_t textureImage_t::interpolateImage(const point3d_t &p) const
 
 colorA_t textureImage_t::getColor(const point3d_t &p) const
 {
-	colorA_t ret = getNoGammaColor(p);
-	
-	if(gamma != 1.f && !image->isHDR()) ret.gammaAdjust(gamma);
-	
+	colorA_t ret = getRawColor(p);
+	ret.linearRGB_from_ColorSpace(colorSpace, gamma);
 	return ret;
 }
 
-colorA_t textureImage_t::getNoGammaColor(const point3d_t &p) const
+colorA_t textureImage_t::getRawColor(const point3d_t &p) const
 {
 	point3d_t p1 = point3d_t(p.x, -p.y, p.z);
 	colorA_t ret(0.f);
@@ -145,14 +143,12 @@ colorA_t textureImage_t::getNoGammaColor(const point3d_t &p) const
 
 colorA_t textureImage_t::getColor(int x, int y, int z) const
 {
-	colorA_t ret = getNoGammaColor(x, y, z);
-	
-	if(gamma != 1.f && !image->isHDR()) ret.gammaAdjust(gamma);
-	
+	colorA_t ret = getRawColor(x, y, z);
+	ret.linearRGB_from_ColorSpace(colorSpace, gamma);
 	return ret;
 }
 
-colorA_t textureImage_t::getNoGammaColor(int x, int y, int z) const
+colorA_t textureImage_t::getRawColor(int x, int y, int z) const
 {
 	int resx=image->getWidth();
 	int resy=image->getHeight();
@@ -261,9 +257,12 @@ texture_t *textureImage_t::factory(paraMap_t &params, renderEnvironment_t &rende
 	double gamma = 1.0;
 	double expadj = 0.0;
 	bool normalmap = false;
+	std::string color_space_string = "sRGB";
+	colorSpaces_t color_space = SRGB;
 	textureImage_t *tex = NULL;
 	imageHandler_t *ih = NULL;
 	params.getParam("interpolate", intpstr);
+	params.getParam("color_space", color_space_string);
 	params.getParam("gamma", gamma);
 	params.getParam("exposure_adjust", expadj);
 	params.getParam("normalmap", normalmap);
@@ -316,8 +315,22 @@ texture_t *textureImage_t::factory(paraMap_t &params, renderEnvironment_t &rende
 		Y_ERROR << "ImageTexture: Couldn't load image file, dropping texture." << yendl;
 		return NULL;
 	}
+
+	if(ih->isHDR())
+	{
+		if(color_space_string != "linear") Y_INFO << "ImageTexture: The image is a HDR/EXR file: forcing linear RGB and ignoring selected color space '" << color_space_string <<"' and the gamma setting." << yendl;
+		color_space = LINEAR_RGB;
+	}
+	else
+	{
+		if(color_space_string == "sRGB") color_space = SRGB;
+		else if(color_space_string == "XYZ") color_space = XYZ_D65;
+		else if(color_space_string == "LinearRGB") color_space = LINEAR_RGB;
+		else if(color_space_string == "Raw_manual_Gamma") color_space = RAW_MANUAL_GAMMA;
+		else color_space = SRGB;
+	}
 	
-	tex = new textureImage_t(ih, intp, gamma);
+	tex = new textureImage_t(ih, intp, color_space, gamma);
 
 	if(!tex)
 	{

--- a/src/textures/imagetex.cc
+++ b/src/textures/imagetex.cc
@@ -318,7 +318,7 @@ texture_t *textureImage_t::factory(paraMap_t &params, renderEnvironment_t &rende
 
 	if(ih->isHDR())
 	{
-		if(color_space_string != "linear") Y_INFO << "ImageTexture: The image is a HDR/EXR file: forcing linear RGB and ignoring selected color space '" << color_space_string <<"' and the gamma setting." << yendl;
+		if(color_space_string != "LinearRGB") Y_INFO << "ImageTexture: The image is a HDR/EXR file: forcing linear RGB and ignoring selected color space '" << color_space_string <<"' and the gamma setting." << yendl;
 		color_space = LINEAR_RGB;
 	}
 	else

--- a/src/textures/imagetex.cc
+++ b/src/textures/imagetex.cc
@@ -326,7 +326,7 @@ texture_t *textureImage_t::factory(paraMap_t &params, renderEnvironment_t &rende
 		if(color_space_string == "sRGB") color_space = SRGB;
 		else if(color_space_string == "XYZ") color_space = XYZ_D65;
 		else if(color_space_string == "LinearRGB") color_space = LINEAR_RGB;
-		else if(color_space_string == "Raw_manual_Gamma") color_space = RAW_MANUAL_GAMMA;
+		else if(color_space_string == "Raw_Manual_Gamma") color_space = RAW_MANUAL_GAMMA;
 		else color_space = SRGB;
 	}
 	

--- a/src/xml_loader/xml-loader.cc
+++ b/src/xml_loader/xml-loader.cc
@@ -22,7 +22,7 @@ using namespace::yafaray;
 
 int main(int argc, char *argv[])
 {
-	std::string xmlLoaderVersion = "YafaRay XML loader version 0.2";
+	std::string xmlLoaderVersion = "YafaRay XML loader version 0.3";
 
 	cliParser_t parse(argc, argv, 2, 1, "You need to set at least a yafaray's valid XML file.");
 
@@ -72,6 +72,7 @@ int main(int argc, char *argv[])
 	parse.setOption("v","version", true, "Displays this program's version.");
 	parse.setOption("h","help", true, "Displays this help text.");
 	parse.setOption("op","output-path", false, "Uses the path in <value> as rendered image output path.");
+	parse.setOption("ics","input-color-space", false, "Sets color space for input color values.\n                                       This does not affect textures, as they have individual color\n                                       space parameters in the XML file.\n                                       Available options:\n\n                                       LinearRGB (default)\n                                       sRGB\n                                       XYZ (experimental)\n");
 	parse.setOption("f","format", false, "Sets the output image format, available formats are:\n\n" + formatString + "\n                                       Default: tga.\n");
 	parse.setOption("t","threads", false, "Overrides threads setting on the XML file, for auto selection use -1.");
 	parse.setOption("a","with-alpha", true, "Enables saving the image with alpha channel.");
@@ -105,6 +106,9 @@ int main(int argc, char *argv[])
 	bool alpha = parse.getFlag("a");
 	std::string format = parse.getOptionString("f");
 	std::string outputPath = parse.getOptionString("op");
+	std::string input_color_space_string = parse.getOptionString("ics");	
+	if(input_color_space_string.empty()) input_color_space_string = "LinearRGB";
+	float input_gamma = 1.f;	//TODO: there is no parse.getOptionFloat available for now, so no way to have the additional option of entering an arbitrary manual input gamma yet. Maybe in the future...
 	int threads = parse.getOptionInteger("t");
 	bool drawparams = parse.getFlag("dp");
 	bool nodrawparams = parse.getFlag("ndp");
@@ -159,7 +163,7 @@ int main(int argc, char *argv[])
 	env->setScene(scene);
 	paraMap_t render;
 	
-	bool success = parse_xml_file(xmlFile.c_str(), scene, env, render);
+	bool success = parse_xml_file(xmlFile.c_str(), scene, env, render, input_color_space_string, input_gamma);
 	if(!success) exit(1);
 	
 	int width=320, height=240;

--- a/src/yafraycore/environment.cc
+++ b/src/yafraycore/environment.cc
@@ -547,7 +547,7 @@ imageFilm_t* renderEnvironment_t::createImageFilm(const paraMap_t &params, color
 	if(color_space_string == "sRGB") color_space = SRGB;
 	else if(color_space_string == "XYZ") color_space = XYZ_D65;
 	else if(color_space_string == "LinearRGB") color_space = LINEAR_RGB;
-	else if(color_space_string == "Raw_manual_Gamma") color_space = RAW_MANUAL_GAMMA;
+	else if(color_space_string == "Raw_Manual_Gamma") color_space = RAW_MANUAL_GAMMA;
 	else color_space = SRGB;
 
 	imageFilm_t::filterType type=imageFilm_t::BOX;

--- a/src/yafraycore/environment.cc
+++ b/src/yafraycore/environment.cc
@@ -520,8 +520,8 @@ imageFilm_t* renderEnvironment_t::createImageFilm(const paraMap_t &params, color
 	const std::string *name=0;
 	const std::string *tiles_order=0;
 	int width=320, height=240, xstart=0, ystart=0;
-	std::string color_space_string = "sRGB";
-	colorSpaces_t color_space = SRGB;
+	std::string color_space_string = "Raw_Manual_Gamma";
+	colorSpaces_t color_space = RAW_MANUAL_GAMMA;
 	float filt_sz = 1.5, gamma=1.f;
 	bool clamp = false;
 	bool showSampledPixels = false;

--- a/src/yafraycore/imagefilm.cc
+++ b/src/yafraycore/imagefilm.cc
@@ -117,8 +117,8 @@ float Lanczos2(float dx, float dy)
 
 imageFilm_t::imageFilm_t (int width, int height, int xstart, int ystart, colorOutput_t &out, float filterSize, filterType filt,
 						  renderEnvironment_t *e, bool showSamMask, int tSize, imageSpliter_t::tilesOrderType tOrder, bool pmA, bool drawParams):
-	flags(0), w(width), h(height), cx0(xstart), cy0(ystart), gamma(1.0), filterw(filterSize*0.5), output(&out),
-	clamp(false), split(true), interactive(true), abort(false), correctGamma(false), splitter(0), pbar(0),
+	flags(0), w(width), h(height), cx0(xstart), cy0(ystart), colorSpace(SRGB), gamma(1.0), filterw(filterSize*0.5), output(&out),
+	clamp(false), split(true), interactive(true), abort(false), splitter(0), pbar(0),
 	env(e), showMask(showSamMask), tileSize(tSize), tilesOrder(tOrder), premultAlpha(pmA), drawParams(drawParams)
 {
 	cx1 = xstart + width;
@@ -347,7 +347,7 @@ void imageFilm_t::finishArea(renderArea_t &a)
 			col = (*image)(i, j).normalized();
 			col.clampRGB0();
 
-			if(correctGamma) col.gammaAdjust(gamma);
+			col.ColorSpace_from_linearRGB(colorSpace, gamma);
 
 			if(premultAlpha) col.alphaPremultiply();
 
@@ -406,7 +406,7 @@ void imageFilm_t::flush(int flags, colorOutput_t *out)
 
 			col.clampRGB0();
 
-			if(correctGamma) col.gammaAdjust(gamma);
+			col.ColorSpace_from_linearRGB(colorSpace, gamma);
 
 			if(drawParams && h - j <= dpHeight && dpimage)
 			{
@@ -622,10 +622,10 @@ void imageFilm_t::setDensityEstimation(bool enable)
 	estimateDensity = enable;
 }
 
-void imageFilm_t::setGamma(float gammaVal, bool enable)
+void imageFilm_t::setColorSpace(colorSpaces_t color_space, float gammaVal)
 {
-	correctGamma = enable;
-	if(gammaVal > 0) gamma = 1.f/gammaVal; //gamma correction means applying gamma curve with 1/gamma
+	colorSpace = color_space;
+	gamma = gammaVal;
 }
 
 void imageFilm_t::setProgressBar(progressBar_t *pb)

--- a/src/yafraycore/imagefilm.cc
+++ b/src/yafraycore/imagefilm.cc
@@ -117,7 +117,7 @@ float Lanczos2(float dx, float dy)
 
 imageFilm_t::imageFilm_t (int width, int height, int xstart, int ystart, colorOutput_t &out, float filterSize, filterType filt,
 						  renderEnvironment_t *e, bool showSamMask, int tSize, imageSpliter_t::tilesOrderType tOrder, bool pmA, bool drawParams):
-	flags(0), w(width), h(height), cx0(xstart), cy0(ystart), colorSpace(SRGB), gamma(1.0), filterw(filterSize*0.5), output(&out),
+	flags(0), w(width), h(height), cx0(xstart), cy0(ystart), colorSpace(RAW_MANUAL_GAMMA), gamma(1.0), filterw(filterSize*0.5), output(&out),
 	clamp(false), split(true), interactive(true), abort(false), splitter(0), pbar(0),
 	env(e), showMask(showSamMask), tileSize(tSize), tilesOrder(tOrder), premultAlpha(pmA), drawParams(drawParams)
 {

--- a/src/yafraycore/xmlparser.cc
+++ b/src/yafraycore/xmlparser.cc
@@ -117,7 +117,7 @@ bool parse_xml_file(const char *filename, scene_t *scene, renderEnvironment_t *e
 	if(color_space_string == "sRGB") input_color_space = SRGB;
 	else if(color_space_string == "XYZ") input_color_space = XYZ_D65;
 	else if(color_space_string == "LinearRGB") input_color_space = LINEAR_RGB;
-	//else if(color_space_string == "Raw_manual_Gamma") input_color_space = RAW_MANUAL_GAMMA; //not available for now
+	//else if(color_space_string == "Raw_Manual_Gamma") input_color_space = RAW_MANUAL_GAMMA; //not available for now
 	else input_color_space = SRGB;
 
 	xmlParser_t parser(env, scene, render, input_color_space, input_gamma);

--- a/src/yafraycore/xmlparser.cc
+++ b/src/yafraycore/xmlparser.cc
@@ -112,7 +112,7 @@ bool parse_xml_file(const char *filename, scene_t *scene, renderEnvironment_t *e
 {
 #if HAVE_XML
 	
-	colorSpaces_t input_color_space = LINEAR_RGB;
+	colorSpaces_t input_color_space = RAW_MANUAL_GAMMA;
 	
 	if(color_space_string == "sRGB") input_color_space = SRGB;
 	else if(color_space_string == "XYZ") input_color_space = XYZ_D65;

--- a/src/yafraycore/xmlparser.cc
+++ b/src/yafraycore/xmlparser.cc
@@ -108,10 +108,20 @@ static xmlSAXHandler my_handler =
 };
 #endif // HAVE_XML
 
-bool parse_xml_file(const char *filename, scene_t *scene, renderEnvironment_t *env, paraMap_t &render)
+bool parse_xml_file(const char *filename, scene_t *scene, renderEnvironment_t *env, paraMap_t &render, std::string color_space_string, float input_gamma)
 {
 #if HAVE_XML
-	xmlParser_t parser(env, scene, render);
+	
+	colorSpaces_t input_color_space = LINEAR_RGB;
+	
+	if(color_space_string == "sRGB") input_color_space = SRGB;
+	else if(color_space_string == "XYZ") input_color_space = XYZ_D65;
+	else if(color_space_string == "LinearRGB") input_color_space = LINEAR_RGB;
+	//else if(color_space_string == "Raw_manual_Gamma") input_color_space = RAW_MANUAL_GAMMA; //not available for now
+	else input_color_space = SRGB;
+
+	xmlParser_t parser(env, scene, render, input_color_space, input_gamma);
+	
 	if (xmlSAXUserParseFile(&my_handler, &parser, filename) < 0)
 	{
 		Y_ERROR << "XMLParser: Parsing the file " << filename << yendl;
@@ -129,8 +139,8 @@ bool parse_xml_file(const char *filename, scene_t *scene, renderEnvironment_t *e
 / parser functions
 =============================================================*/
 
-xmlParser_t::xmlParser_t(renderEnvironment_t *renv, scene_t *sc, paraMap_t &r):
-	env(renv), scene(sc), render(r), current(0), level(0)
+xmlParser_t::xmlParser_t(renderEnvironment_t *renv, scene_t *sc, paraMap_t &r, colorSpaces_t input_color_space, float input_gamma):
+	env(renv), scene(sc), render(r), current(0), level(0), inputGamma(input_gamma), inputColorSpace(input_color_space)
 {
 	cparams = &params;
 	pushState(startEl_document, endEl_document);
@@ -219,7 +229,7 @@ static bool parseNormal(const char **attrs, normal_t &n)
 	return (compoRead == 3);
 }
 
-void parseParam(const char **attrs, parameter_t &param)
+void parseParam(const char **attrs, parameter_t &param, xmlParser_t &parser)
 {
 	if(!attrs[0]) return;
 	if(!attrs[2]) // only one attribute => bool, integer or float value
@@ -251,7 +261,10 @@ void parseParam(const char **attrs, parameter_t &param)
 	switch(type)
 	{
 		case TYPE_POINT: param = parameter_t(p); break;
-		case TYPE_COLOR: param = parameter_t(c); break;
+		case TYPE_COLOR: 
+			c.linearRGB_from_ColorSpace(parser.getInputColorSpace(), parser.getInputGamma());
+			param = parameter_t(c);
+			break;
 	}
 }
 
@@ -599,7 +612,7 @@ void startEl_parammap(xmlParser_t &parser, const char *element, const char **att
 		return;
 	}
 	parameter_t p;
-	parseParam(attrs, p);
+	parseParam(attrs, p, parser);
 	parser.setParam(std::string(element), p);
 }
 
@@ -650,7 +663,7 @@ void endEl_parammap(xmlParser_t &p, const char *element)
 void startEl_paramlist(xmlParser_t &parser, const char *element, const char **attrs)
 {
 	parameter_t p;
-	parseParam(attrs, p);
+	parseParam(attrs, p, parser);
 	parser.setParam(std::string(element), p);
 }
 


### PR DESCRIPTION
Initial changes to try to fix the (apparently broken) YafaRay color pipeline workflow and to replace the simple gamma input/output correction with a proper sRGB decoding/coding in non-HDR files.

More information here:
http://www.yafaray.org/node/670

* Improved Blender Color Space integration.
* The "simple" gamma correction has been replaced by Color Spaces:
	- LinearRGB			Linear values, no gamma correction
	- sRGB				sRGB encoding/decoding
	- XYZ				XYZ (very experimental) support
	- Raw_Manual_Gamma	Raw linear values that allow to set a simple gamma output correction manually

* Fixed: Double application of input gamma to the Blender Color picker. So now scenes will look brighter in general, but they should also look more realistic with less tweaking.
* Gamma input correction no longer used. The color picker floating point color values will be considered already linear and no conversion applied to them.
* For textures, added specific per-texture Color Space and gamma parameters.
* The color values exported to the XML file will be encoded acording to Blender Output Device Color Space setting.
* In yafaray-xml, new commandline option added: "-ics" or "--input-color-space" that allows to select how to interpret the XML color values. By default, for backwards compatibility, color values will be read as "LinearRGB", but using "-ics sRGB", the color values will be interpreted as sRGB. This setting does *not* affect the textures, as they have already per-texture specific color space/gamma parameters.
* Fixed: when exporting to file there was an error in Blender while reopening it to be shown in the Blender image view.

