### PR TITLE
Automatic AA Threshold reduction based on a "floor" for resampled pixels

### DIFF
--- a/include/core_api/imagefilm.h
+++ b/include/core_api/imagefilm.h
@@ -75,10 +75,10 @@ class YAFRAYCORE_EXPORT imageFilm_t
 		/*! Prepare for next pass, i.e. reset area_cnt, check if pixels need resample...
 			\param adaptive_AA if true, flag pixels to be resampled
 			\param threshold color threshold for adaptive antialiasing */
-		void nextPass(bool adaptive_AA, std::string integratorName);
+		int nextPass(bool adaptive_AA, std::string integratorName);
 		/*! Return the next area to be rendered
 			CAUTION! This method MUST be threadsafe!
-			\return false if no area is left to be handed out, true otherwise */
+			\return number of resampled pixels */
 		bool nextArea(renderArea_t &a);
 		/*! Indicate that all pixels inside the area have been sampled for this pass */
 		void finishArea(renderArea_t &a);

--- a/include/core_api/scene.h
+++ b/include/core_api/scene.h
@@ -176,7 +176,7 @@ class YAFRAYCORE_EXPORT scene_t
 		void setBackground(background_t *bg);
 		void setSurfIntegrator(surfaceIntegrator_t *s);
 		void setVolIntegrator(volumeIntegrator_t *v);
-		void setAntialiasing(int numSamples, int numPasses, int incSamples, double threshold);
+		void setAntialiasing(int numSamples, int numPasses, int incSamples, double threshold, int AA_resampled_floor);
 		void setNumThreads(int threads);
 		void setMode(int m){ mode = m; }
 		void depthChannel(bool enable){ do_depth=enable; }
@@ -192,7 +192,7 @@ class YAFRAYCORE_EXPORT scene_t
 		int getNumThreads() const { return nthreads; }
 		int getSignals() const;
 		//! only for backward compatibility!
-		void getAAParameters(int &samples, int &passes, int &inc_samples, CFLOAT &threshold) const;
+		void getAAParameters(int &samples, int &passes, int &inc_samples, CFLOAT &threshold, int &resampled_floor) const;
 		bool doDepth() const { return do_depth; }
 		bool normalizedDepth() const { return norm_depth; }
 
@@ -231,6 +231,8 @@ class YAFRAYCORE_EXPORT scene_t
 		int AA_samples, AA_passes;
 		int AA_inc_samples; //!< sample count for additional passes
 		CFLOAT AA_threshold;
+		int AA_resampled_floor; //!< minimum amount of resampled pixels below which we will automatically decrease the AA_threshold value for the next pass
+		
 		int nthreads;
 		int mode; //!< sets the scene mode (triangle-only, virtual primitives)
 		bool do_depth;

--- a/include/core_api/tiledintegrator.h
+++ b/include/core_api/tiledintegrator.h
@@ -31,6 +31,7 @@ class YAFRAYCORE_EXPORT tiledIntegrator_t: public surfaceIntegrator_t
 		int AA_samples, AA_passes, AA_inc_samples;
 		float iAA_passes; //!< Inverse of AA_passes used for depth map
 		float AA_threshold;
+		int AA_resampled_floor; //!< minimum amount of resampled pixels below which we will automatically decrease the AA_threshold value for the next pass
 		imageFilm_t *imageFilm;
 		float maxDepth; //!< Inverse of max depth from camera within the scene boundaries
 		float minDepth; //!< Distance between camera and the closest object on the scene

--- a/src/yafraycore/environment.cc
+++ b/src/yafraycore/environment.cc
@@ -635,6 +635,7 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	const std::string *name=0;
 	int AA_passes=1, AA_samples=1, AA_inc_samples=1, nthreads=-1;
 	double AA_threshold=0.05;
+	int AA_resampled_floor=0;
 	bool z_chan = false;
 	bool norm_z_chan = true;
 	bool drawParams = false;
@@ -698,6 +699,7 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	AA_inc_samples = AA_samples;
 	params.getParam("AA_inc_samples", AA_inc_samples);
 	params.getParam("AA_threshold", AA_threshold);
+	params.getParam("AA_resampled_floor", AA_resampled_floor);
 	params.getParam("threads", nthreads); // number of threads, -1 = auto detection
 	params.getParam("z_channel", z_chan); // render z-buffer
 	params.getParam("normalize_z_channel", norm_z_chan); // normalize values of z-buffer in range [0,1]
@@ -719,7 +721,7 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	if(z_chan) film->initDepthMap();
 
 	params.getParam("filter_type", name); // AA filter type
-	aaSettings << "AA Settings (" << ((name)?*name:"box") << "): " << AA_passes << ";" << AA_samples << ";" << AA_inc_samples;
+	aaSettings << "AA Settings (" << ((name)?*name:"box") << "): " << AA_passes << ";" << AA_samples << ";" << AA_inc_samples << ";" << AA_resampled_floor;
 
 	film->setAAParams(aaSettings.str());
 	if(custString) film->setCustomString(*custString);
@@ -731,7 +733,7 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	scene.setCamera(cam);
 	scene.setSurfIntegrator((surfaceIntegrator_t*)inte);
 	scene.setVolIntegrator((volumeIntegrator_t*)volInte);
-	scene.setAntialiasing(AA_samples, AA_passes, AA_inc_samples, AA_threshold);
+	scene.setAntialiasing(AA_samples, AA_passes, AA_inc_samples, AA_threshold, AA_resampled_floor);
 	scene.setNumThreads(nthreads);
 	if(backg) scene.setBackground(backg);
 	scene.shadowBiasAuto = adv_auto_shadow_bias_enabled;

--- a/src/yafraycore/imagefilm.cc
+++ b/src/yafraycore/imagefilm.cc
@@ -207,7 +207,7 @@ void imageFilm_t::initDepthMap()
 	if(!depthMap) depthMap = new gray2DImage_t(w, h);
 	else depthMap->clear();
 }
-void imageFilm_t::nextPass(bool adaptive_AA, std::string integratorName)
+int imageFilm_t::nextPass(bool adaptive_AA, std::string integratorName)
 {
 	int n_resample=0;
 
@@ -283,6 +283,8 @@ void imageFilm_t::nextPass(bool adaptive_AA, std::string integratorName)
 		pbar->setTag(passString.str().c_str());
 	}
 	completed_cnt = 0;
+	
+	return n_resample;
 }
 
 bool imageFilm_t::nextArea(renderArea_t &a)

--- a/src/yafraycore/integrator.cc
+++ b/src/yafraycore/integrator.cc
@@ -133,11 +133,12 @@ bool tiledIntegrator_t::render(imageFilm_t *image)
 {
 	std::stringstream passString;
 	imageFilm = image;
-	scene->getAAParameters(AA_samples, AA_passes, AA_inc_samples, AA_threshold);
+	scene->getAAParameters(AA_samples, AA_passes, AA_inc_samples, AA_threshold, AA_resampled_floor);
 	iAA_passes = 1.f / (float) AA_passes;
 	Y_INFO << integratorName << ": Rendering " << AA_passes << " passes" << yendl;
 	Y_INFO << integratorName << ": Min. " << AA_samples << " samples" << yendl;
 	Y_INFO << integratorName << ": "<< AA_inc_samples << " per additional pass" << yendl;
+	Y_INFO << integratorName << ": Resampled pixels floor: "<< AA_resampled_floor << yendl;
 	Y_INFO << integratorName << ": Max. " << AA_samples + std::max(0,AA_passes-1) * AA_inc_samples << " total samples" << yendl;
 	passString << "Rendering pass 1 of " << std::max(1, AA_passes) << "...";
 	Y_INFO << integratorName << ": " << passString.str() << yendl;
@@ -159,8 +160,14 @@ bool tiledIntegrator_t::render(imageFilm_t *image)
 	{
 		if(scene->getSignals() & Y_SIG_ABORT) break;
 		imageFilm->setAAThreshold(AA_threshold);
-		imageFilm->nextPass(true, integratorName);
+		int resampled_pixels = imageFilm->nextPass(true, integratorName);
 		renderPass(AA_inc_samples, AA_samples + (i-1)*AA_inc_samples, true);
+
+		if(resampled_pixels < AA_resampled_floor)
+		{
+			AA_threshold *= 0.9f;
+			Y_INFO << integratorName << ": Resampled pixels (" << resampled_pixels << ") below the floor (" << AA_resampled_floor << "): new AA Threshold for next pass = " << AA_threshold << yendl;
+		} 
 	}
 	maxDepth = 0.f;
 	gTimer.stop("rendert");

--- a/src/yafraycore/scene.cc
+++ b/src/yafraycore/scene.cc
@@ -84,12 +84,13 @@ int scene_t::getSignals() const
 	return sig;
 }
 
-void scene_t::getAAParameters(int &samples, int &passes, int &inc_samples, CFLOAT &threshold) const
+void scene_t::getAAParameters(int &samples, int &passes, int &inc_samples, CFLOAT &threshold, int &resampled_floor) const
 {
 	samples = AA_samples;
 	passes = AA_passes;
 	inc_samples = AA_inc_samples;
 	threshold = AA_threshold;
+	resampled_floor = AA_resampled_floor;
 }
 
 bool scene_t::startGeometry()
@@ -733,12 +734,13 @@ bound_t scene_t::getSceneBound() const
 	return sceneBound;
 }
 
-void scene_t::setAntialiasing(int numSamples, int numPasses, int incSamples, double threshold)
+void scene_t::setAntialiasing(int numSamples, int numPasses, int incSamples, double threshold, int resampled_floor)
 {
 	AA_samples = std::max(1, numSamples);
 	AA_passes = numPasses;
 	AA_inc_samples = (incSamples > 0) ? incSamples : AA_samples;
 	AA_threshold = (CFLOAT)threshold;
+	AA_resampled_floor = resampled_floor;
 }
 
 /*! update scene state to prepare for rendering.


### PR DESCRIPTION
For better noise reduction, as requested in the bugtracker http://yafaray.org/node/690 I've added the functionality of automatically decreasing the AA Threshold before the next pass if the amount of resampled pixels is below a certain "floor" value selectable by the user.

This first version of the feature will have a hardcoded value of 0.9f for AA thresold reduction. This means that, every time a pass resamples fewer pixels than the "floor" selected by the user, the AA Threshold will be decreased by 10% before the next pass.

 Changes to be committed:
	modified:   include/core_api/imagefilm.h
	modified:   include/core_api/scene.h
	modified:   include/core_api/tiledintegrator.h
	modified:   src/yafraycore/environment.cc
	modified:   src/yafraycore/imagefilm.cc
	modified:   src/yafraycore/integrator.cc
	modified:   src/yafraycore/scene.cc