### PR TITLE
Disable differentials for now

### DIFF
--- a/include/core_api/tiledintegrator.h
+++ b/include/core_api/tiledintegrator.h
@@ -35,6 +35,7 @@ class YAFRAYCORE_EXPORT tiledIntegrator_t: public surfaceIntegrator_t
 		imageFilm_t *imageFilm;
 		float maxDepth; //!< Inverse of max depth from camera within the scene boundaries
 		float minDepth; //!< Distance between camera and the closest object on the scene
+		bool diffRaysEnabled;	//!< Differential rays enabled/disabled - for future motion blur / interference features
 
 };
 

--- a/src/integrators/photonintegr.cc
+++ b/src/integrators/photonintegr.cc
@@ -799,7 +799,6 @@ colorA_t photonIntegrator_t::integrate(renderState_t &state, diffRay_t &ray) con
 		material->initBSDF(state, sp, bsdfs);
 		col += material->emit(state, sp, wo);
 		state.includeLights = false;
-		spDifferentials_t spDiff(sp, ray);
 		
 		if(finalGather)
 		{

--- a/src/integrators/sppm.cc
+++ b/src/integrators/sppm.cc
@@ -62,6 +62,8 @@ bool SPPM::render(yafaray::imageFilm_t *image)
 	maxDepth = 0.f;
 	minDepth = 1e38f;
 
+	diffRaysEnabled = false;	//always false for now, reserved for future motion blur and interference features
+
 	if(scene->doDepth() && scene->normalizedDepth()) precalcDepths();
 
 	initializePPM(); // seems could integrate into the preRender
@@ -142,17 +144,20 @@ bool SPPM::renderTile(renderArea_t &a, int n_samples, int offset, bool adaptive,
 					imageFilm->addSample(colorA_t(0.f), j, i, dx, dy, &a); //maybe not need
 					continue;
 				}
-				//setup ray differentials
-				d_ray = camera->shootRay(j+1+dx, i+dy, lens_u, lens_v, wt_dummy);
-				c_ray.xfrom = d_ray.from;
-				c_ray.xdir = d_ray.dir;
-				d_ray = camera->shootRay(j+dx, i+1+dy, lens_u, lens_v, wt_dummy);
-				c_ray.yfrom = d_ray.from;
-				c_ray.ydir = d_ray.dir;
+				if(diffRaysEnabled)
+				{
+					//setup ray differentials
+					d_ray = camera->shootRay(j+1+dx, i+dy, lens_u, lens_v, wt_dummy);
+					c_ray.xfrom = d_ray.from;
+					c_ray.xdir = d_ray.dir;
+					d_ray = camera->shootRay(j+dx, i+1+dy, lens_u, lens_v, wt_dummy);
+					c_ray.yfrom = d_ray.from;
+					c_ray.ydir = d_ray.dir;
+					c_ray.hasDifferentials = true;
+					// col = T * L_o + L_v
+				}
+				
 				c_ray.time = rstate.time;
-				c_ray.hasDifferentials = true;
-				// col = T * L_o + L_v
-				diffRay_t c_ray_copy = c_ray;
 
 				//for sppm progressive
 				int index = i*camera->resX() + j;
@@ -719,9 +724,11 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 					if(s.sampledFlags & BSDF_GLOSSY)
 					{
 						refRay = diffRay_t(sp.P, wi, scene->rayMinDist);
-						if(s.sampledFlags & BSDF_REFLECT) spDiff.reflectedRay(ray, refRay);
-						else if(s.sampledFlags & BSDF_TRANSMIT) spDiff.refractedRay(ray, refRay, material->getMatIOR());
-
+						if(diffRaysEnabled)
+						{
+							if(s.sampledFlags & BSDF_REFLECT) spDiff.reflectedRay(ray, refRay);
+							else if(s.sampledFlags & BSDF_TRANSMIT) spDiff.refractedRay(ray, refRay, material->getMatIOR());
+						}
 						t_ging = traceGatherRay(state, refRay, hp);
 						t_ging.photonFlux *=mcol * W;
 						t_ging.constantRandiance *= mcol * W;
@@ -761,7 +768,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 				if(reflect)
 				{
 					diffRay_t refRay(sp.P, dir[0], scene->rayMinDist);
-					spDiff.reflectedRay(ray, refRay); // compute the ray differentaitl
+					if(diffRaysEnabled) spDiff.reflectedRay(ray, refRay); // compute the ray differentaitl
 					GatherInfo refg = traceGatherRay(state, refRay, hp);
 					if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
 					{
@@ -778,7 +785,7 @@ GatherInfo SPPM::traceGatherRay(yafaray::renderState_t &state, yafaray::diffRay_
 				if(refract)
 				{
 					diffRay_t refRay(sp.P, dir[1], scene->rayMinDist);
-					spDiff.refractedRay(ray, refRay, material->getMatIOR());
+					if(diffRaysEnabled) spDiff.refractedRay(ray, refRay, material->getMatIOR());
 					GatherInfo refg = traceGatherRay(state, refRay, hp);
 					if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
 					{

--- a/src/yafraycore/integrator.cc
+++ b/src/yafraycore/integrator.cc
@@ -151,6 +151,8 @@ bool tiledIntegrator_t::render(imageFilm_t *image)
 	maxDepth = 0.f;
 	minDepth = 1e38f;
 
+	diffRaysEnabled = false;	//always false for now, reserved for future motion blur and interference features
+
 	if(scene->doDepth() && scene->normalizedDepth()) precalcDepths();
 
 	preRender();
@@ -291,15 +293,19 @@ bool tiledIntegrator_t::renderTile(renderArea_t &a, int n_samples, int offset, b
 					imageFilm->addSample(colorA_t(0.f), j, i, dx, dy, &a);
 					continue;
 				}
-				//setup ray differentials
-				d_ray = camera->shootRay(j+1+dx, i+dy, lens_u, lens_v, wt_dummy);
-				c_ray.xfrom = d_ray.from;
-				c_ray.xdir = d_ray.dir;
-				d_ray = camera->shootRay(j+dx, i+1+dy, lens_u, lens_v, wt_dummy);
-				c_ray.yfrom = d_ray.from;
-				c_ray.ydir = d_ray.dir;
+				if(diffRaysEnabled)
+				{
+					//setup ray differentials
+					d_ray = camera->shootRay(j+1+dx, i+dy, lens_u, lens_v, wt_dummy);
+					c_ray.xfrom = d_ray.from;
+					c_ray.xdir = d_ray.dir;
+					d_ray = camera->shootRay(j+dx, i+1+dy, lens_u, lens_v, wt_dummy);
+					c_ray.yfrom = d_ray.from;
+					c_ray.ydir = d_ray.dir;
+					c_ray.hasDifferentials = true;
+				}
+				
 				c_ray.time = rstate.time;
-				c_ray.hasDifferentials = true;
 
 				colorA_t col = integrate(rstate, c_ray);
 				imageFilm->addSample(wt * col, j, i, dx, dy, &a);

--- a/src/yafraycore/mcintegrator.cc
+++ b/src/yafraycore/mcintegrator.cc
@@ -521,8 +521,11 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
                         color_t mcol = material->sample(state, sp, wo, wi, s, W);
                         colorA_t integ = 0.f;
                         refRay = diffRay_t(sp.P, wi, scene->rayMinDist);
-                        if(s.sampledFlags & BSDF_REFLECT) spDiff.reflectedRay(ray, refRay);
-                        else if(s.sampledFlags & BSDF_TRANSMIT) spDiff.refractedRay(ray, refRay, material->getMatIOR());
+                        if(diffRaysEnabled)
+                        {
+			    if(s.sampledFlags & BSDF_REFLECT) spDiff.reflectedRay(ray, refRay);
+			    else if(s.sampledFlags & BSDF_TRANSMIT) spDiff.refractedRay(ray, refRay, material->getMatIOR());
+                        }
                         integ = (color_t)integrate(state, refRay);
 
                         if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
@@ -544,7 +547,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
                         if(s.sampledFlags & BSDF_REFLECT)
                         {
                             refRay = diffRay_t(sp.P, dir[0], scene->rayMinDist);
-                            spDiff.reflectedRay(ray, refRay);
+                            if(diffRaysEnabled) spDiff.reflectedRay(ray, refRay);
                             integ = integrate(state, refRay);
                             if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
                             {
@@ -556,7 +559,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
                         if(s.sampledFlags & BSDF_TRANSMIT)
                         {
                             refRay = diffRay_t(sp.P, dir[1], scene->rayMinDist);
-                            spDiff.refractedRay(ray, refRay, material->getMatIOR());
+                            if(diffRaysEnabled) spDiff.refractedRay(ray, refRay, material->getMatIOR());
                             integ = integrate(state, refRay);
                             if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
                             {
@@ -590,7 +593,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
 			if(reflect)
 			{
 				diffRay_t refRay(sp.P, dir[0], scene->rayMinDist);
-				spDiff.reflectedRay(ray, refRay);
+				if(diffRaysEnabled) spDiff.reflectedRay(ray, refRay);
 				color_t integ = integrate(state, refRay);
 
 				if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))
@@ -603,7 +606,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
 			if(refract)
 			{
 				diffRay_t refRay(sp.P, dir[1], scene->rayMinDist);
-				spDiff.refractedRay(ray, refRay, material->getMatIOR());
+				if(diffRaysEnabled) spDiff.refractedRay(ray, refRay, material->getMatIOR());
 				colorA_t integ = integrate(state, refRay);
 
 				if((bsdfs&BSDF_VOLUMETRIC) && (vol=material->getVolumeHandler(sp.Ng * refRay.dir < 0)))


### PR DESCRIPTION
Differential rays are implemented but not used for now. They are expected to be used in future features like motion blur or interference, but for now the only they are doing is to waste CPU processing power. So I've added a new boolean parameter to disable them for now until those features are implemented.

 Changes to be committed:
	modified:   include/core_api/tiledintegrator.h
	modified:   src/integrators/photonintegr.cc
	modified:   src/integrators/sppm.cc
	modified:   src/yafraycore/integrator.cc
	modified:   src/yafraycore/mcintegrator.cc