### PR TITLE
Compatibility fix for Python 3.8

### DIFF
--- a/src/bindings/yafaray_v3_interface.i
+++ b/src/bindings/yafaray_v3_interface.i
@@ -145,7 +145,7 @@ PyTypeObject yafTile_Type =
 	sizeof(YafTileObject_t),			/* tp_basicsize */
 	0,									/* tp_itemsize */
 	( destructor ) yaf_tile_dealloc,	/* tp_dealloc */
-	nullptr,                       		/* printfunc tp_print; */
+	0,                             		/* tp_print / tp_vectorcall_offset */
 	nullptr,								/* getattrfunc tp_getattr; */
 	nullptr,								/* setattrfunc tp_setattr; */
 	nullptr,								/* tp_compare */ /* DEPRECATED in python 3.0! */


### PR DESCRIPTION
In Python 3.8 (currently in beta), the reserved "tp_print" slot was changed from a function pointer to a number, `Py_ssize_t tp_vectorcall_offset`.
In C, there is no "nullptr"; either a 0 or NULL casts automatically to both pointers and numbers.

Use 0 instead of "nullptr" to be source-compatible both with Python 3.8 and previous versions.